### PR TITLE
Translate exit into correct german word

### DIFF
--- a/chrome/android/java/strings/translations/android_chrome_strings_de.xtb
+++ b/chrome/android/java/strings/translations/android_chrome_strings_de.xtb
@@ -785,5 +785,5 @@ Um neue Lizenzen zu erwerben, stellen Sie eine Internetverbindung her und spiele
 <translation id="3276318574457057212">Regionale Werbung blockieren</translation>
 <translation id="2300239903491866759">Verhindert das Laden regionaler Werbung</translation>
 <translation id="8142327400852603066">Keine zusätzlichen Listen für deine Region verfügbar</translation>
-<translation id="9148058034647219655">Ausgang</translation>
+<translation id="9148058034647219655">Beenden</translation>
 </translationbundle>


### PR DESCRIPTION
This is the correct translation for exiting software.