### PR TITLE
Enable Home button on all devices but disable it by default

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/HomepageManager.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/HomepageManager.java
@@ -112,7 +112,7 @@ public class HomepageManager {
      * @see #isHomepageEnabled
      */
     public boolean getPrefHomepageEnabled() {
-        return mSharedPreferences.getBoolean(PREF_HOMEPAGE_ENABLED, true);
+        return mSharedPreferences.getBoolean(PREF_HOMEPAGE_ENABLED, false);
     }
 
     /**

--- a/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/PartnerBrowserCustomizations.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/PartnerBrowserCustomizations.java
@@ -293,6 +293,7 @@ public class PartnerBrowserCustomizations {
         if (commandLine.hasSwitch(ChromeSwitches.PARTNER_HOMEPAGE_FOR_TESTING)) {
             return commandLine.getSwitchValue(ChromeSwitches.PARTNER_HOMEPAGE_FOR_TESTING);
         }
-        return sHomepage;
+        return "https://brave.com/";
+        // return sHomepage;
     }
 }


### PR DESCRIPTION
Issue #292 re-enabled the Home button, which is great as it can actually be useful (e.g., it provides a convenient way to run at least one bookmarklet, which can multiplex access to other bookmarklets).

I guess you originally disabled the Home button as its default value on almost all devices is completely useless. Additionally, the option to show a Home button is only available in Brave's settings if the device's firmware provides a default homepage (which usually is the manufacturer's or carrier's website); you thus get a different user experience across different devices.

So, this PR provides a more sane (and consistent) default homepage for all devices. It, though, disables the Home button by default, so that it will only be shown if the user has explicitly enabled it in Brave's settings.