### PR TITLE
HTTPS Everywhere  issue fix

### DIFF
--- a/chrome/browser/io_thread.cc
+++ b/chrome/browser/io_thread.cc
@@ -36,6 +36,7 @@
 #include "chrome/browser/data_usage/tab_id_annotator.h"
 #include "chrome/browser/data_use_measurement/chrome_data_use_ascriber.h"
 #include "chrome/browser/net/async_dns_field_trial.h"
+#include "chrome/browser/net/blockers/blockers_worker.h"
 #include "chrome/browser/net/chrome_mojo_proxy_resolver_factory.h"
 #include "chrome/browser/net/chrome_network_delegate.h"
 #include "chrome/browser/net/dns_probe_service.h"
@@ -510,6 +511,8 @@ void IOThread::Init() {
           BrowserThread::GetTaskRunnerForThread(BrowserThread::UI)));
 #endif  // defined(OS_ANDROID)
 
+  globals_->blockers_worker_.reset(new net::blockers::BlockersWorker());
+
   std::map<std::string, std::string> network_quality_estimator_params;
   variations::GetVariationParams(kNetworkQualityEstimatorFieldTrialName,
                                  &network_quality_estimator_params);
@@ -801,6 +804,7 @@ void IOThread::ConstructSystemRequestContext() {
   std::unique_ptr<ChromeNetworkDelegate> chrome_network_delegate(
       new ChromeNetworkDelegate(extension_event_router_forwarder(),
                                 &system_enable_referrers_));
+  chrome_network_delegate->set_blockers_worker(globals_->blockers_worker_);
   // By default, data usage is considered off the record.
   chrome_network_delegate->set_data_use_aggregator(
       globals_->data_use_aggregator.get(),

--- a/chrome/browser/io_thread.h
+++ b/chrome/browser/io_thread.h
@@ -166,6 +166,9 @@ class IOThread : public content::BrowserThreadDelegate {
 
     // Enables Brotli Content-Encoding support
     bool enable_brotli;
+
+    // BlockersWorker instance for blocking
+    std::shared_ptr<net::blockers::BlockersWorker> blockers_worker_;
   };
 
   // |net_log| must either outlive the IOThread or be NULL.

--- a/chrome/browser/net/blockers/blockers_worker.cc
+++ b/chrome/browser/net/blockers/blockers_worker.cc
@@ -82,8 +82,10 @@ namespace blockers {
     BlockersWorker::BlockersWorker() :
         level_db_(nullptr),
         tp_parser_(nullptr),
-        adblock_parser_(nullptr) {
-        base::ThreadRestrictions::SetIOAllowed(true);
+        adblock_parser_(nullptr),
+        tp_initialized_(false),
+        adblock_initialized_(false),
+        adblock_regional_initialized_(false) {
     }
 
     BlockersWorker::~BlockersWorker() {
@@ -103,6 +105,7 @@ namespace blockers {
     }
 
     bool BlockersWorker::InitAdBlock() {
+        base::ThreadRestrictions::AssertIOAllowed();
         std::lock_guard<std::mutex> guard(adblock_init_mutex_);
 
         if (adblock_parser_) {
@@ -122,10 +125,12 @@ namespace blockers {
             return false;
         }
 
+        set_adblock_initialized();
         return true;
     }
 
     bool BlockersWorker::InitAdBlockRegional() {
+        base::ThreadRestrictions::AssertIOAllowed();
         std::lock_guard<std::mutex> guard(adblock_regional_init_mutex_);
 
         if (0 != adblock_regional_parsers_.size()) {
@@ -161,10 +166,12 @@ namespace blockers {
             adblock_regional_parsers_.push_back(parser);
         }
 
+        set_adblock_regional_initialized();
         return true;
     }
 
     bool BlockersWorker::InitTP() {
+        base::ThreadRestrictions::AssertIOAllowed();
         std::lock_guard<std::mutex> guard(tp_init_mutex_);
 
         if (tp_parser_) {
@@ -194,10 +201,12 @@ namespace blockers {
         tp_white_list_.push_back("platform.twitter.com");
         tp_white_list_.push_back("syndication.twitter.com");
 
+        set_tp_initialized();
         return true;
     }
 
     bool BlockersWorker::InitHTTPSE() {
+        base::ThreadRestrictions::AssertIOAllowed();
         std::lock_guard<std::mutex> guard(httpse_init_mutex_);
 
         if (level_db_) {
@@ -282,9 +291,8 @@ namespace blockers {
 
     bool BlockersWorker::shouldAdBlockUrl(const std::string& base_host, const std::string& url,
                                           unsigned int resource_type, bool isAdBlockRegionalEnabled) {
-        base::ThreadRestrictions::ScopedAllowIO allowIo;
-        if (!InitAdBlock()) {
-            return false;
+        if (!isAdBlockerInitialized()) {
+          return false;
         }
 
         FilterOption currentOption = FONoFilterOption;
@@ -302,7 +310,7 @@ namespace blockers {
         }
 
         // Check regional ad block
-        if (!isAdBlockRegionalEnabled || !InitAdBlockRegional()) {
+        if (!isAdBlockRegionalEnabled || !isAdBlockerRegionalInitialized()) {
             return false;
         }
         for (size_t i = 0; i < adblock_regional_parsers_.size(); i++) {
@@ -364,9 +372,8 @@ namespace blockers {
     }
 
     bool BlockersWorker::shouldTPBlockUrl(const std::string& base_host, const std::string& host) {
-        base::ThreadRestrictions::ScopedAllowIO allowIo;
-        if (!InitTP()) {
-            return false;
+        if (!isTPInitialized()) {
+          return false;
         }
 
         if (!tp_parser_->matchesTracker(base_host.c_str(), host.c_str())) {
@@ -396,8 +403,25 @@ namespace blockers {
         return true;
     }
 
+    std::string BlockersWorker::getHTTPSURLFromCacheOnly(const GURL* url) {
+        if (nullptr == url
+          || url->scheme() == "https") {
+            return url->spec();
+        }
+        if (!shouldHTTPSERedirect(url->spec())) {
+            return url->spec();
+        }
+
+        if (recently_used_cache_.data.count(url->spec()) > 0) {
+            addHTTPSEUrlToRedirectList(url->spec());
+            return recently_used_cache_.data[url->spec()];
+        }
+
+        return url->spec();
+    }
+
     std::string BlockersWorker::getHTTPSURL(const GURL* url) {
-        base::ThreadRestrictions::ScopedAllowIO allowIo;
+        base::ThreadRestrictions::AssertIOAllowed();
         if (nullptr == url
           || url->scheme() == "https"
           || !InitHTTPSE()) {
@@ -584,5 +608,34 @@ namespace blockers {
         return correctedto;
     }
 
+    bool BlockersWorker::isTPInitialized() {
+      std::lock_guard<std::mutex> guard(tp_initialized_mutex_);
+      return tp_initialized_;
+    }
+
+    bool BlockersWorker::isAdBlockerInitialized() {
+      std::lock_guard<std::mutex> guard(adblock_initialized_mutex_);
+      return adblock_initialized_;
+    }
+
+    bool BlockersWorker::isAdBlockerRegionalInitialized() {
+      std::lock_guard<std::mutex> guard(adblock_regional_initialized_mutex_);
+      return adblock_regional_initialized_;
+    }
+
+    void BlockersWorker::set_tp_initialized() {
+      std::lock_guard<std::mutex> guard(tp_initialized_mutex_);
+      tp_initialized_ = true;
+    }
+
+    void BlockersWorker::set_adblock_initialized() {
+      std::lock_guard<std::mutex> guard(adblock_initialized_mutex_);
+      adblock_initialized_ = true;
+    }
+
+    void BlockersWorker::set_adblock_regional_initialized() {
+      std::lock_guard<std::mutex> guard(adblock_regional_initialized_mutex_);
+      adblock_regional_initialized_ = true;
+    }
 }  // namespace blockers
 }  // namespace net

--- a/chrome/browser/net/blockers/blockers_worker.cc
+++ b/chrome/browser/net/blockers/blockers_worker.cc
@@ -282,6 +282,7 @@ namespace blockers {
 
     bool BlockersWorker::shouldAdBlockUrl(const std::string& base_host, const std::string& url,
                                           unsigned int resource_type, bool isAdBlockRegionalEnabled) {
+        base::ThreadRestrictions::ScopedAllowIO allowIo;
         if (!InitAdBlock()) {
             return false;
         }
@@ -363,6 +364,7 @@ namespace blockers {
     }
 
     bool BlockersWorker::shouldTPBlockUrl(const std::string& base_host, const std::string& host) {
+        base::ThreadRestrictions::ScopedAllowIO allowIo;
         if (!InitTP()) {
             return false;
         }
@@ -395,6 +397,7 @@ namespace blockers {
     }
 
     std::string BlockersWorker::getHTTPSURL(const GURL* url) {
+        base::ThreadRestrictions::ScopedAllowIO allowIo;
         if (nullptr == url
           || url->scheme() == "https"
           || !InitHTTPSE()) {

--- a/chrome/browser/net/blockers/blockers_worker.h
+++ b/chrome/browser/net/blockers/blockers_worker.h
@@ -41,13 +41,17 @@ public:
     bool shouldTPBlockUrl(const std::string& base_host, const std::string& host);
     bool shouldAdBlockUrl(const std::string& base_host, const std::string& url, unsigned int resource_type,
       bool isAdBlockRegionalEnabled);
+    std::string getHTTPSURLFromCacheOnly(const GURL* url);
     std::string getHTTPSURL(const GURL* url);
+    bool isTPInitialized();
+    bool isAdBlockerInitialized();
+    bool isAdBlockerRegionalInitialized();
 
-private:
     bool InitTP();
     bool InitAdBlock();
     bool InitAdBlockRegional();
     bool InitHTTPSE();
+private:
     std::string applyHTTPSRule(const std::string& originalUrl, const std::string& rule);
     std::vector<std::string> getTPThirdPartyHosts(const std::string& base_host);
 
@@ -58,6 +62,10 @@ private:
 
     void addHTTPSEUrlToRedirectList(const std::string originalUrl);
     bool shouldHTTPSERedirect(const std::string originalUrl);
+
+    void set_tp_initialized();
+    void set_adblock_initialized();
+    void set_adblock_regional_initialized();
 
     std::vector<unsigned char> tp_buffer_;
     std::vector<unsigned char> adblock_buffer_;
@@ -76,12 +84,19 @@ private:
     // inside the tracking protection lib
     std::vector<std::string> tp_white_list_;
 
+    bool tp_initialized_;
+    bool adblock_initialized_;
+    bool adblock_regional_initialized_;
+
     std::mutex httpse_init_mutex_;
     std::mutex adblock_init_mutex_;
     std::mutex adblock_regional_init_mutex_;
     std::mutex tp_init_mutex_;
     std::mutex tp_get_third_party_hosts_mutex_;
     std::mutex httpse_get_urls_redirects_count_mutex_;
+    std::mutex tp_initialized_mutex_;
+    std::mutex adblock_initialized_mutex_;
+    std::mutex adblock_regional_initialized_mutex_;
 };
 
 }  // namespace blockers

--- a/chrome/browser/net/chrome_network_delegate.cc
+++ b/chrome/browser/net/chrome_network_delegate.cc
@@ -138,6 +138,59 @@ void RecordNetworkErrorHistograms(const net::URLRequest* request,
 
 }  // namespace
 
+class PendingRequests {
+public:
+  void Insert(const uint64_t &request_identifier) {
+    pending_requests_.insert(request_identifier);
+  }
+  void Destroy(const uint64_t &request_identifier) {
+    pending_requests_.erase(request_identifier);
+  }
+  bool IsPendingAndAlive(const uint64_t &request_identifier) {
+    bool isPending = pending_requests_.find(request_identifier) != pending_requests_.end();
+    return isPending;
+  }
+private:
+  std::set<uint64_t> pending_requests_;
+  //no need synchronization, should be executed in the same thread content::BrowserThread::IO
+};
+
+struct OnBeforeURLRequestContext
+{
+  OnBeforeURLRequestContext(){}
+  ~OnBeforeURLRequestContext(){}
+
+  int adsBlocked = 0;
+  int trackersBlocked = 0;
+  int httpsUpgrades = 0;
+
+  bool isGlobalBlockEnabled = true;
+  bool blockAdsAndTracking = true;
+  bool isAdBlockRegionalEnabled = true;
+  bool isTPEnabled = true;
+  bool isHTTPSEEnabled = true;
+
+  bool shieldsSetExplicitly = false;
+
+  bool needPerformAdBlock = false;
+  bool needPerformTPBlock = false;
+  bool needPerformHTTPSE = false;
+
+  bool block = false;
+
+  const ResourceRequestInfo* info = nullptr;
+  bool isValidUrl = true;
+  std::string firstparty_host = "";
+  bool check_httpse_redirect = true;
+  GURL UrlCopy;
+  std::string newURL;
+
+  bool pendingAtLeastOnce = false;
+  uint64_t request_identifier = 0;
+
+  DISALLOW_COPY_AND_ASSIGN(OnBeforeURLRequestContext);
+};
+
 ChromeNetworkDelegate::ChromeNetworkDelegate(
     extensions::EventRouterForwarder* event_router,
     BooleanPrefMember* enable_referrers)
@@ -160,6 +213,7 @@ ChromeNetworkDelegate::ChromeNetworkDelegate(
   DCHECK(enable_referrers);
   extensions_delegate_.reset(
       ChromeExtensionsNetworkDelegate::Create(event_router));
+  pending_requests_.reset(new PendingRequests());
 }
 
 ChromeNetworkDelegate::~ChromeNetworkDelegate() {}
@@ -251,148 +305,345 @@ void ChromeNetworkDelegate::InitializePrefsOnUIThread(
 }
 
 int ChromeNetworkDelegate::OnBeforeURLRequest(
-    net::URLRequest* request,
-    const net::CompletionCallback& callback,
-    GURL* new_url) {
+  net::URLRequest* request,
+  const net::CompletionCallback& callback,
+  GURL* new_url) {
+  std::shared_ptr<OnBeforeURLRequestContext> ctx(new OnBeforeURLRequestContext());
 
-  std::string firstparty_host = "";
-  if (request) {
-    firstparty_host = request->first_party_for_cookies().host();
-  }
-  // (TODO)find a better way to handle last first party
-  if (0 == firstparty_host.length()) {
-    firstparty_host = last_first_party_url_.host();
-  } else if (request) {
-    last_first_party_url_ = request->first_party_for_cookies();
-  }
-  // We want to block first party ads as well
-  /*bool firstPartyUrl = false;
-  if (request && (last_first_party_url_ == request->url())) {
-    firstPartyUrl = true;
-  }*/
-  // Ad Block and tracking protection
-  bool isGlobalBlockEnabled = true;
-  bool blockAdsAndTracking = true;
-  bool isHTTPSEEnabled = true;
-  bool shieldsSetExplicitly = false;
-  net::blockers::ShieldsConfig* shieldsConfig =
-    net::blockers::ShieldsConfig::getShieldsConfig();
-  if (request && nullptr != shieldsConfig) {
-      std::string hostConfig = shieldsConfig->getHostSettings(firstparty_host);
-      // It is a length of ALL_SHIELDS_DEFAULT_MASK in ShieldsConfig.java
-      if (hostConfig.length() == 11) {
-        shieldsSetExplicitly  = true;
-        if ('0' == hostConfig[0]) {
-            isGlobalBlockEnabled = false;
-        }
-        if (isGlobalBlockEnabled) {
-            if ('0' ==  hostConfig[2]) {
-                blockAdsAndTracking = false;
-            }
-            if ('0' ==  hostConfig[4]) {
-                isHTTPSEEnabled = false;
-            }
-        }
-      }
-  } else if (nullptr == shieldsConfig){
-      isGlobalBlockEnabled = false;
-  }
-  bool isValidUrl = true;
-  if (request) {
-      isValidUrl = request->url().is_valid();
-      std::string scheme = request->url().scheme();
-      if (scheme.length()) {
-          std::transform(scheme.begin(), scheme.end(), scheme.begin(), ::tolower);
-          if ("http" != scheme && "https" != scheme) {
-              isValidUrl = false;
-          }
-      }
-  }
-  bool isTPEnabled = true;
-	bool block = false;
-  if (enable_tracking_protection_ && !shieldsSetExplicitly) {
-    isTPEnabled = enable_tracking_protection_->GetValue();
-  }
-  int adsBlocked = 0;
-  int trackersBlocked = 0;
-  int httpsUpgrades = 0;
-	if (request
+  int rv = OnBeforeURLRequest_PreBlockersWork(
+       request,
+       callback,
+       new_url,
+       ctx);
+
+   return rv;
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_PreBlockersWork(
+   net::URLRequest* request,
+   const net::CompletionCallback& callback,
+   GURL* new_url,
+   std::shared_ptr<OnBeforeURLRequestContext> ctx)
+ {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+
+   ctx->firstparty_host = "";
+   if (request) {
+     ctx->firstparty_host = request->first_party_for_cookies().host();
+     ctx->request_identifier = request->identifier();
+   }
+   // (TODO)find a better way to handle last first party
+   if (0 == ctx->firstparty_host.length()) {
+     ctx->firstparty_host = last_first_party_url_.host();
+   } else if (request) {
+     last_first_party_url_ = request->first_party_for_cookies();
+   }
+   // We want to block first party ads as well
+   /*bool firstPartyUrl = false;
+   if (request && (last_first_party_url_ == request->url())) {
+     firstPartyUrl = true;
+   }*/
+   // Ad Block and tracking protection
+   ctx->isGlobalBlockEnabled = true;
+   ctx->blockAdsAndTracking = true;
+   ctx->isHTTPSEEnabled = true;
+   ctx->shieldsSetExplicitly = false;
+   net::blockers::ShieldsConfig* shieldsConfig =
+     net::blockers::ShieldsConfig::getShieldsConfig();
+   if (request && nullptr != shieldsConfig) {
+       std::string hostConfig = shieldsConfig->getHostSettings(ctx->firstparty_host);
+       // It is a length of ALL_SHIELDS_DEFAULT_MASK in ShieldsConfig.java
+       if (hostConfig.length() == 11) {
+         ctx->shieldsSetExplicitly  = true;
+         if ('0' == hostConfig[0]) {
+             ctx->isGlobalBlockEnabled = false;
+         }
+         if (ctx->isGlobalBlockEnabled) {
+             if ('0' ==  hostConfig[2]) {
+                 ctx->blockAdsAndTracking = false;
+             }
+             if ('0' ==  hostConfig[4]) {
+                 ctx->isHTTPSEEnabled = false;
+             }
+         }
+       }
+   } else if (nullptr == shieldsConfig){
+       ctx->isGlobalBlockEnabled = false;
+   }
+   ctx->isValidUrl = true;
+   if (request) {
+       ctx->isValidUrl = request->url().is_valid();
+       std::string scheme = request->url().scheme();
+       if (scheme.length()) {
+           std::transform(scheme.begin(), scheme.end(), scheme.begin(), ::tolower);
+           if ("http" != scheme && "https" != scheme) {
+               ctx->isValidUrl = false;
+           }
+       }
+   }
+   ctx->isTPEnabled = true;
+   ctx->block = false;
+   if (enable_tracking_protection_ && !ctx->shieldsSetExplicitly) {
+     ctx->isTPEnabled = enable_tracking_protection_->GetValue();
+   }
+
+  ctx->adsBlocked = 0;
+  ctx->trackersBlocked = 0;
+  ctx->httpsUpgrades = 0;
+
+  int rv = OnBeforeURLRequest_TpBlockPreFileWork(request, callback, new_url, ctx);
+  return rv;
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_TpBlockPreFileWork(
+  net::URLRequest* request,
+  const net::CompletionCallback& callback,
+  GURL* new_url,
+  std::shared_ptr<OnBeforeURLRequestContext> ctx)
+{
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+  ctx->needPerformTPBlock = false;
+  if (request
       //&& !firstPartyUrl
-      && isValidUrl
-      && isGlobalBlockEnabled
-      && blockAdsAndTracking
-      && isTPEnabled
-			&& blockers_worker_->shouldTPBlockUrl(
-					firstparty_host,
-					request->url().host())
-				) {
-		block = true;
-    trackersBlocked++;
-	}
+      && ctx->isValidUrl
+      && ctx->isGlobalBlockEnabled
+      && ctx->blockAdsAndTracking
+      && ctx->isTPEnabled) {
+
+      ctx->needPerformTPBlock = true;
+      if (!blockers_worker_->isTPInitialized() ) {
+        content::BrowserThread::PostTaskAndReply(
+          content::BrowserThread::FILE, FROM_HERE,
+          base::Bind(&ChromeNetworkDelegate::OnBeforeURLRequest_TpBlockFileWork,
+              base::Unretained(this)),
+          base::Bind(base::IgnoreResult(&ChromeNetworkDelegate::OnBeforeURLRequest_TpBlockPostFileWork),
+              base::Unretained(this), base::Unretained(request), callback, new_url, ctx)
+            );
+        ctx->pendingAtLeastOnce = true;
+        pending_requests_->Insert(request->identifier());
+        return net::ERR_IO_PENDING;
+      }
+  }
+
+  int rv = OnBeforeURLRequest_TpBlockPostFileWork(request, callback, new_url, ctx);
+  return rv;
+}
+
+void ChromeNetworkDelegate::OnBeforeURLRequest_TpBlockFileWork() {
+  base::ThreadRestrictions::AssertIOAllowed();
+  DCHECK_CURRENTLY_ON(content::BrowserThread::FILE);
+  blockers_worker_->InitTP();
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_TpBlockPostFileWork(
+  net::URLRequest* request,
+  const net::CompletionCallback& callback,
+  GURL* new_url,
+  std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+
+  if (PendedRequestIsDestroyedOrCancelled(ctx.get(), request)) {
+    return net::OK;
+  }
+
+  if (ctx->needPerformTPBlock){
+    if (blockers_worker_->shouldTPBlockUrl(
+        ctx->firstparty_host,
+        request->url().host())) {
+      ctx->block = true;
+      ctx->trackersBlocked++;
+    }
+  }
+
+  int rv = OnBeforeURLRequest_AdBlockPreFileWork(request, callback, new_url, ctx);
+  return rv;
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_AdBlockPreFileWork(
+  net::URLRequest* request,
+  const net::CompletionCallback& callback,
+  GURL* new_url,
+  std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
   bool isAdBlockEnabled = true;
-  if (enable_ad_block_ && !shieldsSetExplicitly) {
+  if (enable_ad_block_ && !ctx->shieldsSetExplicitly) {
     isAdBlockEnabled = enable_ad_block_->GetValue();
   }
   // Regional ad block flag
-  bool isAdBlockRegionalEnabled = true;
-  if (enable_ad_block_regional_ && !shieldsSetExplicitly) {
-    isAdBlockRegionalEnabled = enable_ad_block_regional_->GetValue();
+  ctx->isAdBlockRegionalEnabled = true;
+  if (enable_ad_block_regional_ && !ctx->shieldsSetExplicitly) {
+    ctx->isAdBlockRegionalEnabled = enable_ad_block_regional_->GetValue();
   }
-	const ResourceRequestInfo* info = ResourceRequestInfo::ForRequest(request);
-	if (!block
+
+  ctx->info = ResourceRequestInfo::ForRequest(request);
+	if (!ctx->block
       //&& !firstPartyUrl
-      && isValidUrl
-      && isGlobalBlockEnabled
-      && blockAdsAndTracking
+      && ctx->isValidUrl
+      && ctx->isGlobalBlockEnabled
+      && ctx->blockAdsAndTracking
       && isAdBlockEnabled
       && request
-      && info
-			&& blockers_worker_->shouldAdBlockUrl(
-					firstparty_host,
-					request->url().spec(),
-					(unsigned int)info->GetResourceType(),
-          isAdBlockRegionalEnabled)) {
-		block = true;
-    adsBlocked++;
+      && ctx->info) {
+        ctx->needPerformAdBlock = true;
+      if (!blockers_worker_->isAdBlockerInitialized() ||
+        (ctx->isAdBlockRegionalEnabled && !blockers_worker_->isAdBlockerRegionalInitialized()) ) {
+
+        content::BrowserThread::PostTaskAndReply(
+          content::BrowserThread::FILE, FROM_HERE,
+          base::Bind(&ChromeNetworkDelegate::OnBeforeURLRequest_AdBlockFileWork,
+              base::Unretained(this), ctx),
+          base::Bind(base::IgnoreResult(&ChromeNetworkDelegate::OnBeforeURLRequest_AdBlockPostFileWork),
+              base::Unretained(this), base::Unretained(request), callback, new_url, ctx)
+            );
+        ctx->pendingAtLeastOnce = true;
+        pending_requests_->Insert(request->identifier());
+        return net::ERR_IO_PENDING;
+      }
 	}
-  bool check_httpse_redirect = true;
-  if (block && info && content::RESOURCE_TYPE_IMAGE == info->GetResourceType()) {
-    check_httpse_redirect = false;
+
+  int rv = OnBeforeURLRequest_AdBlockPostFileWork(request, callback, new_url, ctx);
+  return rv;
+}
+
+void ChromeNetworkDelegate::OnBeforeURLRequest_AdBlockFileWork(std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+  base::ThreadRestrictions::AssertIOAllowed();
+  DCHECK_CURRENTLY_ON(content::BrowserThread::FILE);
+  blockers_worker_->InitAdBlock();
+
+  if (ctx->isAdBlockRegionalEnabled &&
+    !blockers_worker_->isAdBlockerRegionalInitialized()) {
+    blockers_worker_->InitAdBlockRegional();
+  }
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_AdBlockPostFileWork(
+  net::URLRequest* request,
+  const net::CompletionCallback& callback,
+  GURL* new_url,
+  std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+
+  if (PendedRequestIsDestroyedOrCancelled(ctx.get(), request)) {
+    return net::OK;
+  }
+
+  if (ctx->needPerformAdBlock) {
+    if (blockers_worker_->shouldAdBlockUrl(
+        ctx->firstparty_host,
+        request->url().spec(),
+        (unsigned int)ctx->info->GetResourceType(),
+        ctx->isAdBlockRegionalEnabled)) {
+          ctx->block = true;
+          ctx->adsBlocked++;
+      }
+  }
+
+  ctx->check_httpse_redirect = true;
+  if (ctx->block && ctx->info && content::RESOURCE_TYPE_IMAGE == ctx->info->GetResourceType()) {
+    ctx->check_httpse_redirect = false;
     *new_url = GURL(TRANSPARENT1PXGIF);
   }
-  //
 
+   int rv = OnBeforeURLRequest_HttpsePreFileWork(request, callback, new_url, ctx);
+   return rv;
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_HttpsePreFileWork(
+  net::URLRequest* request,
+  const net::CompletionCallback& callback,
+  GURL* new_url,
+  std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+  ctx->needPerformHTTPSE = false;
   // HTTPSE work
-  if (!block
+  if (!ctx->block
       && request
-      && isValidUrl
-      && isGlobalBlockEnabled
-      && isHTTPSEEnabled
-      && check_httpse_redirect
-      && (shieldsSetExplicitly || (enable_httpse_ && enable_httpse_->GetValue()))) {
-    std::string newURL = blockers_worker_->getHTTPSURL(&request->url());
-    if (newURL != request->url().spec()) {
-      *new_url = GURL(newURL);
-      if (last_first_party_url_ != request->url()) {
-        httpsUpgrades++;
-      }
+      && ctx->isValidUrl
+      && ctx->isGlobalBlockEnabled
+      && ctx->isHTTPSEEnabled
+      && ctx->check_httpse_redirect
+      && (ctx->shieldsSetExplicitly || (enable_httpse_ && enable_httpse_->GetValue()))) {
+    ctx->needPerformHTTPSE = true;
+  }
+
+  if (ctx->needPerformHTTPSE) {
+    ctx->newURL = blockers_worker_->getHTTPSURLFromCacheOnly(&request->url());
+    if (ctx->newURL == request->url().spec()) {
+      ctx->UrlCopy = request->url();
+      content::BrowserThread::PostTaskAndReply(
+        content::BrowserThread::FILE, FROM_HERE,
+        base::Bind(&ChromeNetworkDelegate::OnBeforeURLRequest_HttpseFileWork,
+            base::Unretained(this), base::Unretained(request), ctx),
+        base::Bind(base::IgnoreResult(&ChromeNetworkDelegate::OnBeforeURLRequest_HttpsePostFileWork),
+            base::Unretained(this), base::Unretained(request), callback, new_url, ctx)
+          );
+      ctx->pendingAtLeastOnce = true;
+      pending_requests_->Insert(request->identifier());
+      return net::ERR_IO_PENDING;
     }
   }
-  //
-  if (nullptr != shieldsConfig && (0 != trackersBlocked || 0 != adsBlocked || 0 != httpsUpgrades)) {
+
+  int rv = OnBeforeURLRequest_HttpsePostFileWork(request, callback, new_url, ctx);
+  return rv;
+}
+
+void ChromeNetworkDelegate::OnBeforeURLRequest_HttpseFileWork(net::URLRequest* request, std::shared_ptr<OnBeforeURLRequestContext> ctx)
+{
+  base::ThreadRestrictions::AssertIOAllowed();
+  DCHECK_CURRENTLY_ON(content::BrowserThread::FILE);
+  ctx->newURL = blockers_worker_->getHTTPSURL(&ctx->UrlCopy);
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_HttpsePostFileWork(net::URLRequest* request,const net::CompletionCallback& callback,GURL* new_url,std::shared_ptr<OnBeforeURLRequestContext> ctx)
+{
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+
+  if (PendedRequestIsDestroyedOrCancelled(ctx.get(), request)) {
+    return net::OK;
+  }
+
+  if (!ctx->newURL.empty() &&
+    ctx->needPerformHTTPSE &&
+    ctx->newURL != request->url().spec()) {
+    *new_url = GURL(ctx->newURL);
+    if (last_first_party_url_ != request->url()) {
+      ctx->httpsUpgrades++;
+    }
+  }
+
+  int rv = OnBeforeURLRequest_PostBlockers(request, callback, new_url, ctx);
+  return rv;
+}
+
+int ChromeNetworkDelegate::OnBeforeURLRequest_PostBlockers(
+    net::URLRequest* request,
+    const net::CompletionCallback& callback,
+    GURL* new_url,
+    std::shared_ptr<OnBeforeURLRequestContext> ctx)
+{
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+  net::blockers::ShieldsConfig* shieldsConfig =
+     net::blockers::ShieldsConfig::getShieldsConfig();
+  if (nullptr != shieldsConfig && (0 != ctx->trackersBlocked || 0 != ctx->adsBlocked || 0 != ctx->httpsUpgrades)) {
     shieldsConfig->setBlockedCountInfo(last_first_party_url_.spec()
-        , trackersBlocked
-        , adsBlocked
-        , httpsUpgrades
+        , ctx->trackersBlocked
+        , ctx->adsBlocked
+        , ctx->httpsUpgrades
         , 0
         , 0);
   }
 
-  if (block && (nullptr == info || content::RESOURCE_TYPE_IMAGE != info->GetResourceType())) {
-		*new_url = GURL("");
+  if (ctx->block && (nullptr == ctx->info || content::RESOURCE_TYPE_IMAGE != ctx->info->GetResourceType())) {
+    *new_url = GURL("");
 
-		return net::ERR_BLOCKED_BY_ADMINISTRATOR;
-	}
+    if (ctx->pendingAtLeastOnce) {
+      callback.Run(net::ERR_BLOCKED_BY_ADMINISTRATOR);
+    }
+    return net::ERR_BLOCKED_BY_ADMINISTRATOR;
+  }
+
+  //Original chromium part
 
   // TODO(mmenke): Remove ScopedTracker below once crbug.com/456327 is fixed.
   tracked_objects::ScopedTracker tracking_profile1(
@@ -404,7 +655,7 @@ int ChromeNetworkDelegate::OnBeforeURLRequest(
   // which is not blocked.
 
   int error = net::ERR_BLOCKED_BY_ADMINISTRATOR;
-  if (info && content::IsResourceTypeFrame(info->GetResourceType()) &&
+  if (ctx->info && content::IsResourceTypeFrame(ctx->info->GetResourceType()) &&
       url_blacklist_manager_ &&
       url_blacklist_manager_->ShouldBlockRequestForFrame(
           request->url(), &error)) {
@@ -413,6 +664,11 @@ int ChromeNetworkDelegate::OnBeforeURLRequest(
         net::NetLogEventType::CHROME_POLICY_ABORTED_REQUEST,
         net::NetLog::StringCallback("url",
                                     &request->url().possibly_invalid_spec()));
+
+    if (ctx->pendingAtLeastOnce && error != net::ERR_IO_PENDING) {
+      callback.Run(error);
+    }
+
     return error;
   }
 
@@ -468,6 +724,9 @@ int ChromeNetworkDelegate::OnBeforeURLRequest(
                                          true);
   }
 
+  if (ctx->pendingAtLeastOnce && rv != net::ERR_IO_PENDING) {
+    callback.Run(rv);
+  }
   return rv;
 }
 
@@ -562,6 +821,11 @@ void ChromeNetworkDelegate::OnCompleted(net::URLRequest* request,
 }
 
 void ChromeNetworkDelegate::OnURLRequestDestroyed(net::URLRequest* request) {
+  if (pending_requests_->IsPendingAndAlive(request->identifier())) {
+    LOG(ERROR) << "AB: ChromeNetworkDelegate::OnURLRequestDestroyed pending is " << request->identifier() << " PID=" << getpid() << " tid="<< gettid();;
+  }
+  pending_requests_->Destroy(request->identifier());
+
   extensions_delegate_->OnURLRequestDestroyed(request);
 }
 
@@ -783,4 +1047,18 @@ void ChromeNetworkDelegate::ReportDataUsageStats(net::URLRequest* request,
   }
 
   data_use_aggregator_->ReportDataUse(request, tx_bytes, rx_bytes);
+}
+
+bool ChromeNetworkDelegate::PendedRequestIsDestroyedOrCancelled(OnBeforeURLRequestContext* ctx, net::URLRequest* request) {
+  if (ctx->pendingAtLeastOnce) {
+    if ( !pending_requests_->IsPendingAndAlive(ctx->request_identifier)){
+      LOG(ERROR) << "AB: request " << ctx->request_identifier << "has been destroyed while being pended" << " PID=" << getpid() << " tid="<< gettid();
+      return true;
+    }
+    if (request->status().status() == net::URLRequestStatus::CANCELED) {
+      LOG(ERROR) << "AB: request  " << ctx->request_identifier << " is cancelled" << " PID=" << getpid() << " tid="<< gettid();
+      return true;
+    }
+  }
+  return false;
 }

--- a/chrome/browser/net/chrome_network_delegate.cc
+++ b/chrome/browser/net/chrome_network_delegate.cc
@@ -821,11 +821,7 @@ void ChromeNetworkDelegate::OnCompleted(net::URLRequest* request,
 }
 
 void ChromeNetworkDelegate::OnURLRequestDestroyed(net::URLRequest* request) {
-  if (pending_requests_->IsPendingAndAlive(request->identifier())) {
-    LOG(ERROR) << "AB: ChromeNetworkDelegate::OnURLRequestDestroyed pending is " << request->identifier() << " PID=" << getpid() << " tid="<< gettid();;
-  }
   pending_requests_->Destroy(request->identifier());
-
   extensions_delegate_->OnURLRequestDestroyed(request);
 }
 
@@ -1051,12 +1047,8 @@ void ChromeNetworkDelegate::ReportDataUsageStats(net::URLRequest* request,
 
 bool ChromeNetworkDelegate::PendedRequestIsDestroyedOrCancelled(OnBeforeURLRequestContext* ctx, net::URLRequest* request) {
   if (ctx->pendingAtLeastOnce) {
-    if ( !pending_requests_->IsPendingAndAlive(ctx->request_identifier)){
-      LOG(ERROR) << "AB: request " << ctx->request_identifier << "has been destroyed while being pended" << " PID=" << getpid() << " tid="<< gettid();
-      return true;
-    }
-    if (request->status().status() == net::URLRequestStatus::CANCELED) {
-      LOG(ERROR) << "AB: request  " << ctx->request_identifier << " is cancelled" << " PID=" << getpid() << " tid="<< gettid();
+    if ( !pending_requests_->IsPendingAndAlive(ctx->request_identifier)
+      || request->status().status() == net::URLRequestStatus::CANCELED) {
       return true;
     }
   }

--- a/chrome/browser/net/chrome_network_delegate.h
+++ b/chrome/browser/net/chrome_network_delegate.h
@@ -56,6 +56,9 @@ namespace policy {
 class URLBlacklistManager;
 }
 
+struct OnBeforeURLRequestContext;
+class PendingRequests;
+
 // ChromeNetworkDelegate is the central point from within the chrome code to
 // add hooks into the network stack.
 class ChromeNetworkDelegate : public net::NetworkDelegateImpl {
@@ -227,6 +230,56 @@ class ChromeNetworkDelegate : public net::NetworkDelegateImpl {
                             int64_t tx_bytes,
                             int64_t rx_bytes);
 
+  // Separate IO and FILE thread workers for blocker
+  int OnBeforeURLRequest_PreBlockersWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  int OnBeforeURLRequest_TpBlockPreFileWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  void OnBeforeURLRequest_TpBlockFileWork();
+  int OnBeforeURLRequest_TpBlockPostFileWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  int OnBeforeURLRequest_AdBlockPreFileWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  void OnBeforeURLRequest_AdBlockFileWork(std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  int OnBeforeURLRequest_AdBlockPostFileWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  int OnBeforeURLRequest_HttpsePreFileWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  void OnBeforeURLRequest_HttpseFileWork(
+            net::URLRequest* request,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  int OnBeforeURLRequest_HttpsePostFileWork(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  int OnBeforeURLRequest_PostBlockers(
+            net::URLRequest* request,
+            const net::CompletionCallback& callback,
+            GURL* new_url,
+            std::shared_ptr<OnBeforeURLRequestContext> ctx);
+  bool PendedRequestIsDestroyedOrCancelled(
+            OnBeforeURLRequestContext* ctx,
+            net::URLRequest* request);
+
   std::unique_ptr<ChromeExtensionsNetworkDelegate> extensions_delegate_;
 
   void* profile_;
@@ -262,6 +315,7 @@ class ChromeNetworkDelegate : public net::NetworkDelegateImpl {
   // (TODO)find a better way to handle last first party
   GURL last_first_party_url_;
 
+  std::auto_ptr<PendingRequests> pending_requests_;
 
   DISALLOW_COPY_AND_ASSIGN(ChromeNetworkDelegate);
 };

--- a/chrome/browser/net/chrome_network_delegate.h
+++ b/chrome/browser/net/chrome_network_delegate.h
@@ -20,7 +20,6 @@
 #include "components/domain_reliability/monitor.h"
 #include "components/prefs/pref_member.h"
 #include "net/base/network_delegate_impl.h"
-#include "chrome/browser/net/blockers/blockers_worker.h"
 
 class ChromeExtensionsNetworkDelegate;
 class PrefService;
@@ -48,6 +47,9 @@ class InfoMap;
 
 namespace net {
 class URLRequest;
+namespace blockers {
+class BlockersWorker;
+}
 }
 
 namespace policy {
@@ -134,6 +136,9 @@ class ChromeNetworkDelegate : public net::NetworkDelegateImpl {
   void set_data_use_aggregator(
       data_usage::DataUseAggregator* data_use_aggregator,
       bool is_data_usage_off_the_record);
+
+  void set_blockers_worker(
+        std::shared_ptr<net::blockers::BlockersWorker> blockers_worker);
 
   // Binds the pref members to |pref_service| and moves them to the IO thread.
   // |enable_referrers| cannot be nullptr, the others can.
@@ -252,7 +257,7 @@ class ChromeNetworkDelegate : public net::NetworkDelegateImpl {
   bool is_data_usage_off_the_record_;
 
   // Blockers
-  net::blockers::BlockersWorker blockers_worker_;
+  std::shared_ptr<net::blockers::BlockersWorker> blockers_worker_;
 
   // (TODO)find a better way to handle last first party
   GURL last_first_party_url_;

--- a/chrome/browser/profiles/profile_io_data.cc
+++ b/chrome/browser/profiles/profile_io_data.cc
@@ -1054,6 +1054,8 @@ void ProfileIOData::Init(
   chrome_network_delegate->set_data_use_aggregator(
       io_thread_globals->data_use_aggregator.get(), IsOffTheRecord());
 
+  chrome_network_delegate->set_blockers_worker(io_thread_globals->blockers_worker_);
+
   std::unique_ptr<net::NetworkDelegate> network_delegate =
       ConfigureNetworkDelegate(profile_params_->io_thread,
                                std::move(chrome_network_delegate));


### PR DESCRIPTION
This is a fix for issue https://github.com/brave/browser-android-tabs/issues/387 . 
There are two parts of this fix: 
1) moving BlockersWorker instance up to have it shared between regular tab and incognito tab (commit https://github.com/AlexeyBarabash/browser-android-tabs/commit/1a1fc82051be5a9288e001edeeea81add0ce7cd7);
2) moving file operations into FILE browser thread (remaining commits https://github.com/AlexeyBarabash/browser-android-tabs/commit/6f24558d1c8edb1a2e2287b3b0246ccdeeb5e6e3 and https://github.com/AlexeyBarabash/browser-android-tabs/commit/c567f6a1814cdb69470e023d75288029329de825 ).