### PR TITLE
Install channels

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -127,6 +127,17 @@ by a child template that "extends" this file.
         android:networkSecurityConfig="@xml/network_security_config"
         {% block extra_application_attributes %}{% endblock %}>
 
+        <!-- For Google Play Store Campaign Measurement-->
+        <receiver android:name="org.chromium.chrome.browser.init.InstallReferrerReceiver"
+           android:enabled="true"
+           android:exported="true"
+           android:permission="android.permission.INSTALL_PACKAGES"
+           >
+           <intent-filter>
+               <action android:name="com.android.vending.INSTALL_REFERRER" />
+           </intent-filter>
+         </receiver>
+
         <!-- MixPanel proxy server -->
         <meta-data android:name="com.mixpanel.android.MPConfig.EventsEndpoint"
               android:value="https://metric-proxy.brave.com/track" />

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/ChromeBrowserInitializer.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/ChromeBrowserInitializer.java
@@ -39,6 +39,7 @@ import org.chromium.chrome.browser.ChromeSwitches;
 import org.chromium.chrome.browser.FileProviderHelper;
 import org.chromium.chrome.browser.crash.LogcatExtractionRunnable;
 import org.chromium.chrome.browser.download.DownloadManagerService;
+import org.chromium.chrome.browser.init.InstallationSourceInformer;
 import org.chromium.chrome.browser.preferences.PrefServiceBridge;
 import org.chromium.chrome.browser.preferences.privacy.PrivacyPreferencesManager;
 import org.chromium.chrome.browser.services.GoogleServicesManager;
@@ -80,6 +81,7 @@ public class ChromeBrowserInitializer {
 
     private boolean mAdBlockInitCalled = false;
     private boolean mUpdateStatsCalled = false;
+    private boolean mInstallationSourceChecked = false;
 
     List<String> mWhitelistedRegionalLocales = Arrays.asList("ru", "uk", "be", "hi");
 
@@ -139,6 +141,15 @@ public class ChromeBrowserInitializer {
       new UpdateStatsAsyncTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    private void CheckInstallationSource() {
+      if (mInstallationSourceChecked) {
+        return;
+      }
+
+      mInstallationSourceChecked = true;
+      new CheckInstallationSourceAsyncTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
     // Stats update
     class UpdateStatsAsyncTask extends AsyncTask<Void,Void,Long> {
         protected Long doInBackground(Void... params) {
@@ -166,6 +177,33 @@ public class ChromeBrowserInitializer {
             return null;
         }
     }
+
+    class CheckInstallationSourceAsyncTask extends AsyncTask<Void,Void,Long> {
+       protected Long doInBackground(Void... params) {
+           try {
+             Context context = mApplication.getApplicationContext();
+             // A list with valid installers package name
+             List<String> validInstallers = new ArrayList<>(Arrays.asList("com.android.vending", "com.google.android.feedback"));
+
+             // The package name of the app that has installed your app
+             final String installer = context.getPackageManager().getInstallerPackageName(context.getPackageName());
+             Log.i(TAG, "Installation source detection, installer=" + installer);
+
+             // true if your app has been downloaded from Play Store
+             boolean fromPlayStore = installer != null && validInstallers.contains(installer);
+             Log.i(TAG, "Installation source detection, fromPlayStore="+fromPlayStore);
+             if (!fromPlayStore) {
+               InstallationSourceInformer.InformFromOther();
+             }
+           }
+           catch(Exception exc) {
+               // not critical
+               Log.i(TAG, "Installation source detection: ex " + exc);
+           }
+
+           return null;
+       }
+   }
 
     // Tracking protection data download
     private void DownloadTrackingProtectionData() {
@@ -587,6 +625,7 @@ public class ChromeBrowserInitializer {
 
         InitAdBlock();
         UpdateStats();
+        CheckInstallationSource();
     }
 
     private void waitForDebuggerIfNeeded() {

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/InstallReferrerReceiver.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/InstallReferrerReceiver.java
@@ -1,0 +1,22 @@
+package org.chromium.chrome.browser.init;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import org.chromium.base.Log;
+
+import org.chromium.chrome.browser.init.InstallationSourceInformer;
+
+public class InstallReferrerReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+      String referrer = intent.getStringExtra("referrer");
+        Log.i("TAG", "InstallReferrerReceiver: referrer: " + referrer);
+
+      if (referrer != null && referrer.contains("utm_source") ) {
+        InstallationSourceInformer.InformFromAdWords();
+      } else {
+        InstallationSourceInformer.InformFromPlayMarket();
+      }
+    }
+}

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/InstallReferrerReceiver.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/InstallReferrerReceiver.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.chromium.chrome.browser.init;
 
 import android.content.BroadcastReceiver;

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 
 package org.chromium.chrome.browser.init;
 
@@ -12,11 +16,15 @@ public class InstallationSourceInformer {
   private static final String PREF_MIXPANEL_INSTALL_SOURCE_INFORMED = "mixpanel_installation_source_informed";
 
   public static void InformFromOther() {
-    Inform("Others");
+    //Disabled until we not ensured InformFromAdWords works well
+    //Inform("Others");
+    Log.i("TAG", "InstallationSourceInformer.InformFromOther skip send info");
   }
 
   public static void InformFromPlayMarket() {
-    Inform("Google Play");
+    //Disabled until we not ensured InformFromAdWords works well
+    //Inform("Google Play");
+    Log.i("TAG", "InstallationSourceInformer.InformFromPlayMarket skip send info");
   }
 
   public static void InformFromAdWords() {
@@ -24,7 +32,6 @@ public class InstallationSourceInformer {
   }
 
   private static synchronized void Inform(String sourceName) {
-
     Log.i("TAG", "InstallationSourceInformer, sourceName=" + sourceName);
     if (IsAlreadyInformed()) {
       Log.i("TAG", "InstallationSourceInformer, already informed");

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java
@@ -12,11 +12,11 @@ public class InstallationSourceInformer {
   private static final String PREF_MIXPANEL_INSTALL_SOURCE_INFORMED = "mixpanel_installation_source_informed";
 
   public static void InformFromOther() {
-    Inform("Other");
+    Inform("Others");
   }
 
   public static void InformFromPlayMarket() {
-    Inform("Play Market");
+    Inform("Google Play");
   }
 
   public static void InformFromAdWords() {
@@ -25,17 +25,15 @@ public class InstallationSourceInformer {
 
   private static synchronized void Inform(String sourceName) {
 
-    Log.i("TAG", "InstallationSourceInformer, sourceName="+sourceName);
+    Log.i("TAG", "InstallationSourceInformer, sourceName=" + sourceName);
     if (IsAlreadyInformed()) {
       Log.i("TAG", "InstallationSourceInformer, already informed");
       return;
     }
 
-return;//not to spoil Miz Panel Data until all is tested
-/*
-    MixPanelWorker.SendEvent("App Installation Source Detected", "Installation Source", sourceName);
+    MixPanelWorker.SendEvent("Installed from " + sourceName);
     SetAlreadyInformed();
-*/  }
+  }
 
   private static boolean IsAlreadyInformed() {
     boolean installSourceInformed = ContextUtils.getAppSharedPreferences().getBoolean(

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java
@@ -1,0 +1,51 @@
+
+package org.chromium.chrome.browser.init;
+
+import android.content.SharedPreferences;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.Log;
+import org.chromium.chrome.browser.MixPanelWorker;
+
+
+public class InstallationSourceInformer {
+  private static final String PREF_MIXPANEL_INSTALL_SOURCE_INFORMED = "mixpanel_installation_source_informed";
+
+  public static void InformFromOther() {
+    Inform("Other");
+  }
+
+  public static void InformFromPlayMarket() {
+    Inform("Play Market");
+  }
+
+  public static void InformFromAdWords() {
+    Inform("AdWords");
+  }
+
+  private static synchronized void Inform(String sourceName) {
+
+    Log.i("TAG", "InstallationSourceInformer, sourceName="+sourceName);
+    if (IsAlreadyInformed()) {
+      Log.i("TAG", "InstallationSourceInformer, already informed");
+      return;
+    }
+
+return;//not to spoil Miz Panel Data until all is tested
+/*
+    MixPanelWorker.SendEvent("App Installation Source Detected", "Installation Source", sourceName);
+    SetAlreadyInformed();
+*/  }
+
+  private static boolean IsAlreadyInformed() {
+    boolean installSourceInformed = ContextUtils.getAppSharedPreferences().getBoolean(
+      PREF_MIXPANEL_INSTALL_SOURCE_INFORMED, false);
+    return installSourceInformed;
+  }
+
+  private static void SetAlreadyInformed() {
+    SharedPreferences.Editor sharedPreferencesEditor = ContextUtils.getAppSharedPreferences().edit();
+    sharedPreferencesEditor.putBoolean(PREF_MIXPANEL_INSTALL_SOURCE_INFORMED, true);
+    sharedPreferencesEditor.apply();
+  }
+}

--- a/chrome/android/java_sources.gni
+++ b/chrome/android/java_sources.gni
@@ -511,6 +511,8 @@ chrome_java_sources = [
   "java/src/org/chromium/chrome/browser/init/StatsUpdater.java",
   "java/src/org/chromium/chrome/browser/init/EmptyBrowserParts.java",
   "java/src/org/chromium/chrome/browser/init/InvalidStartupDialog.java",
+  "java/src/org/chromium/chrome/browser/init/InstallReferrerReceiver.java",
+  "java/src/org/chromium/chrome/browser/init/InstallationSourceInformer.java",
   "java/src/org/chromium/chrome/browser/init/NativeInitializationController.java",
   "java/src/org/chromium/chrome/browser/init/ProcessInitializationHandler.java",
   "java/src/org/chromium/chrome/browser/installedapp/InstalledAppProviderFactory.java",


### PR DESCRIPTION
PR for https://github.com/brave/browser-android-tabs/issues/415.
It should send to mix panel these data:
- "Installed from AdWords" - if the application was installed from Google Play and was driven by advertisement link;
- "Installed from Google Play" - if the application was installed from Google Play in a regular way (this event is disabled for now);
- "Installed from Others" - if the application was installed from other sources, like GitHub releases section (this event is disabled for now).