### PR TITLE
allow play audio in background

### DIFF
--- a/media/blink/webmediaplayer_impl.cc
+++ b/media/blink/webmediaplayer_impl.cc
@@ -791,6 +791,12 @@ bool WebMediaPlayerImpl::HasAudio() const {
   return pipeline_metadata_.has_audio;
 }
 
+bool WebMediaPlayerImpl::HasVideoNonEmptySize() const {
+  DCHECK(main_task_runner_->BelongsToCurrentThread());
+
+  return pipeline_metadata_.has_video && pipeline_metadata_.natural_size.width() != 0 && pipeline_metadata_.natural_size.height() != 0;
+}
+
 void WebMediaPlayerImpl::EnabledAudioTracksChanged(
     const blink::WebVector<blink::WebMediaPlayer::TrackId>& enabledTrackIds) {
   DCHECK(main_task_runner_->BelongsToCurrentThread());
@@ -2620,7 +2626,10 @@ bool WebMediaPlayerImpl::ShouldPauseVideoWhenHidden() const {
   // If suspending background video, pause any video that's not remoted or
   // not unlocked to play in the background.
   if (IsBackgroundedSuspendEnabled()) {
-    if (!HasVideo())
+    //pipeline_metadata_.has_video is true for MediaPlayerRenderer,
+    //see media/base/pipeline_metadata.h. This is a workaround to allow audio
+    //streams be played in background.
+    if (!HasVideoNonEmptySize())
       return false;
 
 #if defined(OS_ANDROID)

--- a/media/blink/webmediaplayer_impl.h
+++ b/media/blink/webmediaplayer_impl.h
@@ -139,6 +139,8 @@ class MEDIA_BLINK_EXPORT WebMediaPlayerImpl
   // True if the loaded media has a playable video/audio track.
   bool HasVideo() const override;
   bool HasAudio() const override;
+  // True is has video and it's frame size is not zero
+  bool HasVideoNonEmptySize() const;
 
   void EnabledAudioTracksChanged(
       const blink::WebVector<blink::WebMediaPlayer::TrackId>& enabledTrackIds)


### PR DESCRIPTION
This is a fix for https://github.com/brave/browser-android-tabs/issues/367 .
The behavior is like Chrome, audio keeps playing. I did not do the option in settings, because audio can be paused through the system notification area.