### PR TITLE
hide safe browsing preference

### DIFF
--- a/chrome/android/java/res/xml/privacy_preferences.xml
+++ b/chrome/android/java/res/xml/privacy_preferences.xml
@@ -22,10 +22,10 @@
         android:key="safe_browsing_scout_reporting"
         android:title="@string/safe_browsing_scout_reporting_title"
         android:summary="@string/safe_browsing_scout_reporting_summary" />-->
-    <org.chromium.chrome.browser.preferences.ChromeBaseCheckBoxPreference
+    <!--<org.chromium.chrome.browser.preferences.ChromeBaseCheckBoxPreference
         android:key="safe_browsing"
         android:title="@string/safe_browsing_title"
-        android:summary="@string/safe_browsing_summary" />
+        android:summary="@string/safe_browsing_summary" />-->
     <org.chromium.chrome.browser.preferences.ChromeBaseCheckBoxPreference
         android:key="httpse"
         android:title="@string/httpse_title"

--- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java
@@ -41,7 +41,7 @@ public class PrivacyPreferences extends PreferenceFragment
             "safe_browsing_extended_reporting";
     private static final String PREF_SAFE_BROWSING_SCOUT_REPORTING =
             "safe_browsing_scout_reporting";*/
-    private static final String PREF_SAFE_BROWSING = "safe_browsing";
+    //private static final String PREF_SAFE_BROWSING = "safe_browsing";
     private static final String PREF_FINGERPRINTING_PROTECTION = "fingerprinting_protection";
     private static final String PREF_HTTPSE = "httpse";
     private static final String PREF_TRACKING_PROTECTION = "tracking_protection";
@@ -110,10 +110,10 @@ public class PrivacyPreferences extends PreferenceFragment
                     ? PREF_SAFE_BROWSING_EXTENDED_REPORTING : PREF_SAFE_BROWSING_SCOUT_REPORTING;
         preferenceScreen.removePreference(findPreference(extended_reporting_pref_to_remove));*/
 
-        ChromeBaseCheckBoxPreference safeBrowsingPref =
-                (ChromeBaseCheckBoxPreference) findPreference(PREF_SAFE_BROWSING);
-        safeBrowsingPref.setOnPreferenceChangeListener(this);
-        safeBrowsingPref.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
+        // ChromeBaseCheckBoxPreference safeBrowsingPref =
+        //         (ChromeBaseCheckBoxPreference) findPreference(PREF_SAFE_BROWSING);
+        // safeBrowsingPref.setOnPreferenceChangeListener(this);
+        // safeBrowsingPref.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
 
         ChromeBaseCheckBoxPreference fingerprintingProtectionPref =
                 (ChromeBaseCheckBoxPreference) findPreference(PREF_FINGERPRINTING_PROTECTION);
@@ -162,9 +162,9 @@ public class PrivacyPreferences extends PreferenceFragment
         String key = preference.getKey();
         if (PREF_SEARCH_SUGGESTIONS.equals(key)) {
             PrefServiceBridge.getInstance().setSearchSuggestEnabled((boolean) newValue);
-        } else if (PREF_SAFE_BROWSING.equals(key)) {
+        } /*else if (PREF_SAFE_BROWSING.equals(key)) {
             PrefServiceBridge.getInstance().setSafeBrowsingEnabled((boolean) newValue);
-        } else if (PREF_FINGERPRINTING_PROTECTION.equals(key)) {
+        }*/ else if (PREF_FINGERPRINTING_PROTECTION.equals(key)) {
             PrefServiceBridge.getInstance().setFingerprintingProtectionEnabled((boolean) newValue);
             MixPanelWorker.SendEvent("Fingerprinting Protection Option Changed", "Fingerprinting Protection", newValue);
         } else if (PREF_HTTPSE.equals(key)) {
@@ -241,11 +241,11 @@ public class PrivacyPreferences extends PreferenceFragment
                     prefServiceBridge.isSafeBrowsingExtendedReportingEnabled());
         }*/
 
-        CheckBoxPreference safeBrowsingPref =
-                (CheckBoxPreference) findPreference(PREF_SAFE_BROWSING);
-        if (safeBrowsingPref != null) {
-            safeBrowsingPref.setChecked(prefServiceBridge.isSafeBrowsingEnabled());
-        }
+        // CheckBoxPreference safeBrowsingPref =
+        //         (CheckBoxPreference) findPreference(PREF_SAFE_BROWSING);
+        // if (safeBrowsingPref != null) {
+        //     safeBrowsingPref.setChecked(prefServiceBridge.isSafeBrowsingEnabled());
+        // }
 
         //Preference doNotTrackPref = findPreference(PREF_DO_NOT_TRACK);
         //if (doNotTrackPref != null) {
@@ -300,9 +300,9 @@ public class PrivacyPreferences extends PreferenceFragment
                         || PREF_SAFE_BROWSING_SCOUT_REPORTING.equals(key)) {
                     return prefs.isSafeBrowsingExtendedReportingManaged();
                 }*/
-                if (PREF_SAFE_BROWSING.equals(key)) {
+                /*if (PREF_SAFE_BROWSING.equals(key)) {
                     return prefs.isSafeBrowsingManaged();
-                }
+                }*/
                 if (PREF_NETWORK_PREDICTIONS.equals(key)) {
                     return prefs.isNetworkPredictionManaged();
                 }

--- a/chrome/android/java/strings/android_chrome_strings.grd
+++ b/chrome/android/java/strings/android_chrome_strings.grd
@@ -541,12 +541,12 @@ CHAR-LIMIT guidelines:
       <message name="IDS_SAFE_BROWSING_SCOUT_REPORTING_SUMMARY" desc="Summary for reporting data to detect bad apps/sites.">
         Automatically send some system information and page content to Google to help detect dangerous apps and sites
       </message>-->
-      <message name="IDS_SAFE_BROWSING_TITLE" desc="Title for safe browsing.">
+      <!--<message name="IDS_SAFE_BROWSING_TITLE" desc="Title for safe browsing.">
         Safe Browsing
       </message>
       <message name="IDS_SAFE_BROWSING_SUMMARY" desc="Summary for safe browsing.">
         Protect you and your device from dangerous sites
-      </message>
+      </message>-->
       <message name="IDS_NTP_SITES_EXPLORATION_CATEGORY_PERSONALIZED_TITLE" desc="In the Sites Explore UI, title of the Personalized category.">
         Personalized
       </message>


### PR DESCRIPTION
This is for https://github.com/brave/browser-android-tabs/issues/475 , hides the `Settings->Privacy->Safe Browsing` option.