### PR TITLE
fix for some videos could not be played in background

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/DisableVideoPauseOnBackground.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/DisableVideoPauseOnBackground.java
@@ -17,7 +17,7 @@ public class DisableVideoPauseOnBackground {
     }
 
     private static boolean NeedToDisable(Tab tab) {
-        boolean bRet = tab != null && tab.getUrl().contains("https://m.youtube.com/watch?v");
+        boolean bRet = tab != null && tab.getUrl().contains("https://m.youtube.com/watch?");
         return bRet;
     }
 


### PR DESCRIPTION
This PR should fix https://github.com/brave/browser-android-tabs/issues/511 issue.
The url was `https://m.youtube.com/watch?sns=tw&v=kVafBagmNg0`, so js code for pause has not been patched, because expected `watch?v=`.