### PR TITLE
use TLS 1.3 by default; fixes #812

### DIFF
--- a/chrome/browser/ssl/ssl_config_service_manager_pref.cc
+++ b/chrome/browser/ssl/ssl_config_service_manager_pref.cc
@@ -185,7 +185,10 @@ SSLConfigServiceManagerPref::SSLConfigServiceManagerPref(
   } else if (tls13_variant == "draft28") {
     tls13_value = switches::kTLS13VariantDraft28;
     version_value = switches::kSSLVersionTLSv13;
-  } else if (tls13_variant == "final") {
+  } else if (tls13_variant == "final" ||
+             // If the experimental flag for TLS1.3 is set to default,
+             // then assume we do want to use TLS1.3
+             tls13_variant.empty()) {
     tls13_value = switches::kTLS13VariantFinal;
     version_value = switches::kSSLVersionTLSv13;
   }


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/812 .

Another way would be to modify experimental settings default list
`components/flags_ui/pref_service_flags_storage.cc`
```
// static
void PrefServiceFlagsStorage::RegisterPrefs(PrefRegistrySimple* registry) {
  auto default_list = std::make_unique<base::ListValue>();
  default_list->AppendString("tls13-variant@11");
  registry->RegisterListPref(prefs::kEnabledLabsExperiments, std::move(default_list));
}
```
but this would not work if device already had some experimental flags enabled and gets updated to new Brave release.
