### PR TITLE
android_webview: Update GetUserAgent overrides

### DIFF
--- a/android_webview/browser/aw_safe_browsing_ui_manager.cc
+++ b/android_webview/browser/aw_safe_browsing_ui_manager.cc
@@ -44,7 +44,7 @@ void RecordIsWebViewViewable(bool isViewable) {
 network::mojom::NetworkContextParamsPtr CreateDefaultNetworkContextParams() {
   network::mojom::NetworkContextParamsPtr network_context_params =
       network::mojom::NetworkContextParams::New();
-  network_context_params->user_agent = GetUserAgent();
+  network_context_params->user_agent = GetUserAgent("");
   return network_context_params;
 }
 

--- a/android_webview/browser/net/aw_http_user_agent_settings.cc
+++ b/android_webview/browser/net/aw_http_user_agent_settings.cc
@@ -31,9 +31,9 @@ std::string AwHttpUserAgentSettings::GetAcceptLanguage() const {
   return last_http_accept_language_;
 }
 
-std::string AwHttpUserAgentSettings::GetUserAgent() const {
+std::string AwHttpUserAgentSettings::GetUserAgent(const std::string& strHost) const {
   DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
-  return android_webview::GetUserAgent();
+  return android_webview::GetUserAgent(strHost);
 }
 
 }  // namespace android_webview

--- a/android_webview/browser/net/aw_http_user_agent_settings.h
+++ b/android_webview/browser/net/aw_http_user_agent_settings.h
@@ -24,7 +24,7 @@ class AwHttpUserAgentSettings : public net::HttpUserAgentSettings {
 
   // net::HttpUserAgentSettings implementation
   std::string GetAcceptLanguage() const override;
-  std::string GetUserAgent() const override;
+  std::string GetUserAgent(const std::string& strHost) const override;
 
  private:
   // Avoid re-processing by caching the last value from the locale and the

--- a/android_webview/common/aw_content_client.cc
+++ b/android_webview/common/aw_content_client.cc
@@ -30,7 +30,7 @@ std::string GetProduct() {
   return version_info::GetProductNameAndVersionForUserAgent();
 }
 
-std::string GetUserAgent() {
+std::string GetUserAgent(const std::string& strHost) {
   // "Version/4.0" had been hardcoded in the legacy WebView.
   std::string product = "Version/4.0 " + GetProduct();
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
@@ -38,7 +38,7 @@ std::string GetUserAgent() {
     product += " Mobile";
   }
   return content::BuildUserAgentFromProductAndExtraOSInfo(
-      product, "; wv", true /* include_android_build_number */);
+      product, "; wv", true /* include_android_build_number */, "");
 }
 
 void AwContentClient::AddAdditionalSchemes(Schemes* schemes) {
@@ -52,8 +52,8 @@ std::string AwContentClient::GetProduct() const {
   return android_webview::GetProduct();
 }
 
-std::string AwContentClient::GetUserAgent() const {
-  return android_webview::GetUserAgent();
+std::string AwContentClient::GetUserAgent(const std::string& strHost) const {
+  return android_webview::GetUserAgent(strHost);
 }
 
 base::string16 AwContentClient::GetLocalizedString(int message_id) const {

--- a/android_webview/common/aw_content_client.h
+++ b/android_webview/common/aw_content_client.h
@@ -16,14 +16,14 @@ struct GPUInfo;
 namespace android_webview {
 
 std::string GetProduct();
-std::string GetUserAgent();
+std::string GetUserAgent(const std::string& strHost);
 
 class AwContentClient : public content::ContentClient {
  public:
   // ContentClient implementation.
   void AddAdditionalSchemes(Schemes* schemes) override;
   std::string GetProduct() const override;
-  std::string GetUserAgent() const override;
+  std::string GetUserAgent(const std::string& strHost) const override;
   base::string16 GetLocalizedString(int message_id) const override;
   base::StringPiece GetDataResource(
       int resource_id,


### PR DESCRIPTION
* This makes the functions match the updates done by the commit
  "Customize UA for duckduckgo".
* Errored out when building the system webview

I'm trying to integrate Brave as the default system browser and webview provider, which requires the building of monochrome_public_apk (or system_webview_apk).