### PR TITLE
Fixed loading rewards page in foreground tab

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsPanelPopup.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsPanelPopup.java
@@ -475,7 +475,7 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, FaviconHelp
 
         TabModelSelectorImpl tabbedModeTabModelSelector = (TabModelSelectorImpl) mActivity.getTabModelSelector();
         Tab tab = tabbedModeTabModelSelector.openNewTab(
-                loadUrlParams, TabLaunchType.FROM_BROWSER_ACTIONS, null, false);
+                loadUrlParams, TabLaunchType.FROM_CHROME_UI, null, false);
         assert tab != null;
 
         return tab;


### PR DESCRIPTION
Fix https://github.com/brave/browser-android-tabs/issues/1005