### PR TITLE
Add Cancel button on loading after sync init; addresses #979

### DIFF
--- a/chrome/android/java/res/layout/brave_sync_done.xml
+++ b/chrome/android/java/res/layout/brave_sync_done.xml
@@ -184,6 +184,13 @@
             android:layout_width="match_parent"
             android:visibility="invisible" />
 
+        <Button android:id="@+id/brave_sync_btn_cancel_loading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel"
+            android:visibility="gone"
+            style="@style/BraveSyncButton" />
+
         <Button android:id="@+id/brave_sync_btn_add_device"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/979

This PR adds a `Cancel` button while sync initialization and device loading.
This button is not shown when sync chain does already exist.

![screenshot_20190125-005536](https://user-images.githubusercontent.com/24739341/51713898-2442e080-203c-11e9-9172-28ee6dee2e8e.png)
