### PR TITLE
Move custom headers from NavigationRequest to ChromeNetworkDelegate::OnBeforeStartTransaction

### DIFF
--- a/chrome/browser/net/chrome_network_delegate.cc
+++ b/chrome/browser/net/chrome_network_delegate.cc
@@ -32,6 +32,7 @@
 #include "chrome/browser/net/blockers/blockers_worker.h"
 #include "chrome/browser/net/chrome_extensions_network_delegate.h"
 #include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/stats_updater.h"
 #include "chrome/browser/task_manager/task_manager_interface.h"
 #include "chrome/common/buildflags.h"
 #include "chrome/common/net/safe_search_util.h"
@@ -733,10 +734,42 @@ int ChromeNetworkDelegate::OnBeforeURLRequest_PostBlockers(
   return rv;
 }
 
+namespace {
+
+void SetCustomHeaders(
+    net::URLRequest* request,
+    net::HttpRequestHeaders* headers) {
+  if (request && headers) {
+    // Look for and setup custom headers
+    std::string customHeaders = stats_updater::GetCustomHeadersForHost(
+        request->url().host());
+    if (customHeaders.size()) {
+      std::string key;
+      std::string value;
+      size_t pos = customHeaders.find("\n");
+      if (pos == std::string::npos) {
+          key = customHeaders;
+          value = "";
+      } else {
+          key = customHeaders.substr(0, pos);
+          value = customHeaders.substr(pos + 1);
+      }
+      if (key.size()) {
+          headers->SetHeader(key, value);
+      }
+    }
+  }
+}
+
+}  // namespace
+
 int ChromeNetworkDelegate::OnBeforeStartTransaction(
     net::URLRequest* request,
     net::CompletionOnceCallback callback,
     net::HttpRequestHeaders* headers) {
+
+  SetCustomHeaders(request, headers);
+
   return extensions_delegate_->NotifyBeforeStartTransaction(
       request, std::move(callback), headers);
 }

--- a/content/browser/frame_host/navigation_request.cc
+++ b/content/browser/frame_host/navigation_request.cc
@@ -15,7 +15,6 @@
 #include "chrome/browser/net/blockers/blockers_worker.h"
 #include "chrome/browser/net/blockers/shields_config.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/stats_updater.h"
 #include "content/browser/appcache/appcache_navigation_handle.h"
 #include "content/browser/appcache/chrome_appcache_service.h"
 #include "content/browser/child_process_security_policy_impl.h"
@@ -524,24 +523,6 @@ NavigationRequest::NavigationRequest(
 
   net::HttpRequestHeaders headers;
   headers.AddHeadersFromString(begin_params_->headers);
-
-  // Look for and setup custom headers
-  std::string customHeaders = stats_updater::GetCustomHeadersForHost(common_params_.url.host());
-  if (customHeaders.size()) {
-      std::string key;
-      std::string value;
-      size_t pos = customHeaders.find("\n");
-      if (pos == std::string::npos) {
-          key = customHeaders;
-          value = "";
-      } else {
-          key = customHeaders.substr(0, pos);
-          value = customHeaders.substr(pos + 1);
-      }
-      if (key.size()) {
-          headers.SetHeader(key, value);
-      }
-  }
 
   AddAdditionalRequestHeaders(
       &headers, std::move(embedder_additional_headers), common_params_.url,


### PR DESCRIPTION
This fixes setting custom headers on resources requests.