### PR TITLE
Load devices early on start and when devices list is shown

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveSyncWorker.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveSyncWorker.java
@@ -812,9 +812,7 @@ public class BraveSyncWorker {
 
     public ArrayList<ResolvedRecordToApply> GetAllDevices() {
         ArrayList<ResolvedRecordToApply> result_devices = new ArrayList<ResolvedRecordToApply>();
-        if (!mSyncIsReady.IsReady()) {
-            return result_devices;
-        }
+
         String object = nativeGetObjectIdByLocalId(DEVICES_NAMES);
         if (object.isEmpty()) {
             return result_devices;
@@ -1955,9 +1953,14 @@ public class BraveSyncWorker {
     private void DeviceResolver(List<ResolvedRecordToApply> resolvedRecords) {
         //Log.i(TAG, "DeviceResolver: resolvedRecords.size(): " + resolvedRecords.size());
         assert null != resolvedRecords;
-        if (0 == resolvedRecords.size()) {
+
+        if (0 == resolvedRecords.size() &&
+            (mSyncScreensObserver == null || !mSyncScreensObserver.shouldLoadDevices())) {
+            // When there are no changes in devices from sync cloud, but devices
+            // page is currently opened in sync settings, reload in anyway devices list
             return;
         }
+
         String object = nativeGetObjectIdByLocalId(DEVICES_NAMES);
 
         List<ResolvedRecordToApply> existingRecords = new ArrayList<ResolvedRecordToApply>();

--- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/BraveSyncScreensObserver.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/BraveSyncScreensObserver.java
@@ -32,4 +32,9 @@ public interface BraveSyncScreensObserver {
      * Informs when the sync is reset
      */
     public void onResetSync();
+
+    /**
+     * Returns true if sync settings with devices list is currently shown
+     */
+    public boolean shouldLoadDevices();
 }

--- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/BraveSyncScreensPreference.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/BraveSyncScreensPreference.java
@@ -512,6 +512,15 @@ public class BraveSyncScreensPreference extends PreferenceFragment
                           Log.e(TAG, "onResetSync exception: " + exc);
                       }
                   }
+
+                  @Override
+                  public boolean shouldLoadDevices() {
+                      if (null == getActivity() || View.VISIBLE != mScrollViewSyncDone.getVisibility()) {
+                          // No need to load devices for other pages
+                          return false;
+                      }
+                      return true;
+                  }
               };
           }
           application.mBraveSyncWorker.InitJSWebView(mSyncScreensObserver);


### PR DESCRIPTION
Fix https://github.com/brave/browser-android-tabs/issues/1080 .

## Steps to Reproduce
1. Connect Android device the existing sync chain which already has bookmarks. BC-BC is fine
2. Wait until bookmarks appear on Android device
3. Close browser by trowing out from the app list
4. Launch browser and as fast as possible go to Settings => Sync Beta, it is important to do it fast.
   If wait a little before go to settings, then issue could not be reproduced.

## Actual result:
1. it stuck on `LOADING DEVICES...` phase for a long time

## Expected result:
1. device list is displayed according to the sync chain
