### PR TITLE
URLEncoder.encode for bookmark urls

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveSyncWorker.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveSyncWorker.java
@@ -49,6 +49,7 @@ import org.json.JSONObject;
 
 import java.lang.IllegalArgumentException;
 import java.lang.Runnable;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -745,12 +746,21 @@ public class BraveSyncWorker {
       return in.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
+    private String UrlEncode(String url) {
+        try {
+            String urlEncoded = URLEncoder.encode(url, "utf-8");
+            return urlEncoded;
+        } catch (UnsupportedEncodingException ex) {
+            return url;
+        }
+    }
+
     private StringBuilder CreateBookmarkRecord(String url, String title, boolean isFolder, long parentFolderId,
               String parentFolderObjectId, String customTitle, long lastAccessedTime, long creationTime, String favIcon,
               String order) {
         StringBuilder bookmarkRequest = new StringBuilder("bookmark:");
         bookmarkRequest.append("{ site:");
-        bookmarkRequest.append("{ location: \"").append(url).append("\", ");
+        bookmarkRequest.append("{ location: \"").append(UrlEncode(url)).append("\", ");
         if (!isFolder) {
             bookmarkRequest.append("title: \"").append(replaceUnsupportedCharacters(title)).append("\", ");
             bookmarkRequest.append("customTitle: \"").append(replaceUnsupportedCharacters(customTitle)).append("\", ");
@@ -762,7 +772,7 @@ public class BraveSyncWorker {
                 bookmarkRequest.append("customTitle: \"").append(replaceUnsupportedCharacters(title)).append("\", ");
             }
         }
-        bookmarkRequest.append("favicon: \"").append(favIcon).append("\", ");
+        bookmarkRequest.append("favicon: \"").append(UrlEncode(favIcon)).append("\", ");
         bookmarkRequest.append("lastAccessedTime: ").append(lastAccessedTime).append(", ");
         bookmarkRequest.append("creationTime: ").append(creationTime).append("}, ");
         bookmarkRequest.append("isFolder: ").append(isFolder).append(", ");


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/1173 .

This PR puts additional `URLEncoder.encode` when the record is sent to 
`mWebContents.getNavigationController().loadUrl(new LoadUrlParams(mJsToExecute.toString()));`

At this point browser does decode of url, so original bookmark url  `...%22...` becomes `..."...` and it ruins json:
brief
```
location: "https://brave.github.io/brave-ui .... knob-Donations=[{"tokens": ... "
                                                                  ^
```


full
```
(function() {f1(
{}
[{ 
action: 0, 
deviceId: [0], 
objectId: [27, 110, 106, 44, 158, 191, 110, 173, 220, 89, 163, 185, 94, 38, 56, 177], 
objectData: 'bookmark', 
syncTimestamp: 1550842154935, 
bookmark:{ 
site:{ 
location: "https://brave.github.io/brave-ui/?knob-Label Color=#303030&knob-Title=Bart Baker&knob-Content=empty&knob-Button Types=default&knob-Heading text=Some text&knob-Text=Example UnstyledButton&knob-Margin=15px&knob-Counter=123123&knob-Balance=5&knob-Description=Some Description&knob-Section Title=Some Section Title&knob-Decoration=none&knob-Counter Color=orange&knob-Description Color=black&knob-Provider=YouTube&knob-Donations=[{"tokens":"1.0","converted":"0.30","selected":false},{"tokens":"5.0","converted":"1.50","selected":false},{"tokens":"10.0","converted":"3.00","selected":false}]&knob-Optional Label=Beta&knob-Color=#000&knob-Enable Tor?=true&knob-Heading Level=1&knob-Weight=normal&knob-Width=78px&knob-Left Label=Some label here&knob-Page Title Label=Beta&knob-Claimed grants=[{"tokens":"8.0","expireDate":"7/15/2018"},{"tokens":"10.0","expireDate":"9/10/2018"},{"tokens":"10.0","expireDate":"10/10/2018"}]&knob-Feature Title=Some Feature Title&knob-Font style=italic&knob-Size=16px&knob-Right Label=Some label here too&knob-Padding=0px&knob-Button Sizes=medium&knob-Font size=13px&knob-Font Size=13px&knob-Link Text=Some text&knob-Disallow user select?=auto&knob-with separator?=true&knob-Label=Hello Button&knob-Height=32px&knob-Open?=true&knob-Page Title=New About Page&knob-Summary text=Some text here&selectedKind=Feature Components/Sync/Page&selectedStory=Enabled Content&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook/actions/actions-panel", 
title: "Storybook", 
customTitle: "Storybook", 
favicon: "", 
lastAccessedTime: 0, 
creationTime: 0}, 
isFolder: false, 
order: "1.0.0.1", 
parentFolderObjectId: null} 
}, null]
]

)})()

```
As a solution for the specific case described in  https://github.com/brave/browser-android-tabs/issues/1173 would be enough to wrap url with single quotes  ` ... location: 'https://' ...` . But url can contain any encoded symbol, like `https://www.bing.com/search?q=%27%23%27%23%23%22%23%23%23%25%23%23%23%23&qs=n&form=QBRE&sp=-1&pq=%27%23%27%23%23%22%23%23%23%25&sc=0-10&sk=&cvid=01852BA0B3BE4DF4A86E9DDB33668A5A` . So the additional encoding was done.

Additional encoding is compensated by implicit decoding at `mWebContents.getNavigationController().loadUrl(new LoadUrlParams(mJsToExecute.toString()));` line.

