### PR TITLE
Hide the container that holds the top toolbar. New tab buttons are

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java
@@ -1085,7 +1085,7 @@ public class ToolbarPhone
      */
     private void updateUrlExpansionAnimation() {
         if (isInTabSwitcherMode()) {
-            mToolbarButtonsContainer.setVisibility(VISIBLE);
+            mToolbarButtonsContainer.setVisibility(GONE);
             return;
         }
 


### PR DESCRIPTION
accessible from the triple dot settings button at the bottom.

New tab button doesn't appear at the top during TabSwitching,
per inflateTabSwitchingResources()

Closes https://github.com/brave/browser-android-tabs/issues/1197