### PR TITLE
Fixed text for wrong device time while syncing

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/BraveSyncScreensPreference.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/BraveSyncScreensPreference.java
@@ -268,7 +268,7 @@ public class BraveSyncScreensPreference extends PreferenceFragment
                           }
                           if (null != message && !message.isEmpty()) {
                               if (message.equals("Credential server response 400. Signed request body of the client timestamp is required.")) {
-                                  getResources().getString(R.string.sync_requires_correct_time);
+                                  message = getResources().getString(R.string.sync_requires_correct_time);
                               }
                               message = " [" + message + "]";
                           }

--- a/chrome/android/java/strings/android_chrome_strings.grd
+++ b/chrome/android/java/strings/android_chrome_strings.grd
@@ -4177,7 +4177,7 @@ However, you aren’t invisible. Going private doesn’t hide your browsing from
         Sync could not be setup
       </message>
       <message name="IDS_SYNC_REQUIRES_CORRECT_TIME" desc="The message for the dialog where the user notified about sync setup failure.">
-        You might be having wrong system time or timezone setup on your device. Please setup the correct time and timezone
+        Your computer's clock may be set to the wrong time, or to the wrong time-zone. Check your clock settings
       </message>
 
       <!-- Brave stats -->

--- a/chrome/android/java/strings/strings.xml
+++ b/chrome/android/java/strings/strings.xml
@@ -38,7 +38,7 @@
     <string name="enter_code_words_sync">Enter code words</string>
     <string name="sync_device">Sync device</string>
     <string name="sync_device_failure">Sync could not be setup</string>
-    <string name="sync_requires_correct_time">You might be having wrong system time or timezone setup on your device. Please setup the correct time and timezone</string>
+    <string name="sync_requires_correct_time">Your computer's clock may be set to the wrong time, or to the wrong time-zone. Check your clock settings</string>
 
     <string name="brave_stats_text_trackers">Trackers
 Blocked</string>


### PR DESCRIPTION
Addition to https://github.com/brave/browser-android-tabs/pull/1418, fixing the text with regards to brave-core notices https://github.com/brave/brave-core/pull/2155#pullrequestreview-223025391 and https://github.com/brave/brave-browser/issues/4011.

![Screenshot_20190405-144542](https://user-images.githubusercontent.com/24739341/55630450-62881900-57be-11e9-9303-1227c702ebed.png)
