### PR TITLE
Rewards Settings: Ads disabled messages

### DIFF
--- a/components/brave_rewards_ui/resources/storage.ts
+++ b/components/brave_rewards_ui/resources/storage.ts
@@ -39,14 +39,14 @@ export const defaultState: Rewards.State = {
   adsData: {
     adsEnabled: false,
     adsPerHour: 0,
-    adsUIEnabled: false,
+    adsUIEnabled: false, // build flag supports ads
     adsNotificationsReceived: 0,
     adsEstimatedEarnings: 0,
-    adsIsSupported: false
+    adsIsSupported: false // region supports ads
   },
   autoContributeList: [],
   reports: {},
-  safetyNetFailed: false,
+  safetyNetFailed: false, // security status supports ads
   recurringList: [],
   tipsList: [],
   tipsLoad: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -842,9 +842,9 @@
       }
     },
     "@ctrl/tinycolor": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-2.4.0.tgz",
-      "integrity": "sha512-ZLjdsst8/ENM6spDmh3qPQSM+iDSerTGjA05KhAXog7o/aOa9tn7qzWMeOtJzGaDMmsBLxh4IuZ5GH7nfda9gg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-2.5.1.tgz",
+      "integrity": "sha512-I5SD9ii2gh/4/LNyg+dXG6S5B41bZyQyXCldSZxNHMlNnFtDgo1h7Tn/PiCZ8qlRkAFmv+kx1ay/gtTyCVrGcw==",
       "dev": true
     },
     "@types/bittorrent-protocol": {
@@ -2118,8 +2118,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#cad4e14be8de73f059b9ec7de826bd363fe5ba7f",
-      "from": "github:brave/brave-ui#cad4e14be8de73f059b9ec7de826bd363fe5ba7f",
+      "version": "github:brave/brave-ui#16f766e89ff56bbe809319f89286bc364971f225",
+      "from": "github:brave/brave-ui#16f766e89ff56bbe809319f89286bc364971f225",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/react-dom": "^16.0.9",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "brave/brave-ui#cad4e14be8de73f059b9ec7de826bd363fe5ba7f",
+    "brave-ui": "brave/brave-ui#16f766e89ff56bbe809319f89286bc364971f225",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Integrates brave-ui features from https://github.com/brave/brave-ui/pull/477 which gives us support to show an alert on BoxMobile (as well as an 'extra' content area for https://github.com/brave/browser-android-tabs/issues/1580)

Also requires brave-core strings update at https://github.com/brave/brave-core/pull/2508

Fix https://github.com/brave/browser-android-tabs/issues/1519 by showing 3 alerts:
1. Ads isn't supported due to region
2. Ads isn't supported due to SafetyNet fail
3. Ads is not supported due to the build configuration
