### PR TITLE
Ads settings disabled messages

### DIFF
--- a/chrome/browser/ui/webui/brave_webui_source.cc
+++ b/chrome/browser/ui/webui/brave_webui_source.cc
@@ -70,7 +70,8 @@ void CustomizeWebUIHTMLSource(const std::string &name, content::WebUIDataSource*
         { "adsDisabledText",  IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT },
         { "adsCurrentEarnings",  IDS_BRAVE_REWARDS_LOCAL_ADS_CURRENT_EARNINGS },
         { "adsNotificationsReceived",  IDS_BRAVE_REWARDS_LOCAL_ADS_NOTIFICATIONS_RECEIVED },  // NOLINT
-        { "adsNotSupported", IDS_BRAVE_REWARDS_LOCAL_ADS_NOT_SUPPORTED },
+        { "adsNotSupportedRegion", IDS_BRAVE_REWARDS_LOCAL_ADS_NOT_SUPPORTED_REGION },
+        { "adsNotSupportedDevice", IDS_BRAVE_REWARDS_LOCAL_ADS_NOT_SUPPORTED_DEVICE },
         { "adsPaymentDate",  IDS_BRAVE_REWARDS_LOCAL_ADS_PAYMENT_DATE },
         { "adsPagesViewed",  IDS_BRAVE_REWARDS_LOCAL_ADS_PAGES_VIEWED },
         { "adsPerHour",  IDS_BRAVE_REWARDS_LOCAL_ADS_PER_HOUR },

--- a/components/brave_rewards_ui/resources/components/pageWallet.tsx
+++ b/components/brave_rewards_ui/resources/components/pageWallet.tsx
@@ -59,7 +59,8 @@ class PageWallet extends React.Component<Props, State> {
     return grants.map((grant: Rewards.Grant) => {
       return {
         tokens: convertProbiToFixed(grant.probi),
-        expireDate: new Date(grant.expiryTime * 1000).toLocaleDateString()
+        expireDate: new Date(grant.expiryTime * 1000).toLocaleDateString(),
+        type: grant.type
       }
     })
   }

--- a/components/definitions/rewards.d.ts
+++ b/components/definitions/rewards.d.ts
@@ -75,10 +75,10 @@ declare namespace Rewards {
     altcurrency?: string
     probi: string
     expiryTime: number
+    type: string
     captcha?: string
     hint?: string
     status?: GrantStatus
-    type?: string
   }
 
   export interface WalletProperties {

--- a/package-lock.json
+++ b/package-lock.json
@@ -842,9 +842,9 @@
       }
     },
     "@ctrl/tinycolor": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-2.5.1.tgz",
-      "integrity": "sha512-I5SD9ii2gh/4/LNyg+dXG6S5B41bZyQyXCldSZxNHMlNnFtDgo1h7Tn/PiCZ8qlRkAFmv+kx1ay/gtTyCVrGcw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-2.5.2.tgz",
+      "integrity": "sha512-0uQs1pXZtZByI5pLlWEWRnNmXmD/IWv7rgwDkuh5jGkBMC3gCVGYKbxlUglct8EBj3U6Ada1iTTSrNeep/rzlA==",
       "dev": true
     },
     "@types/bittorrent-protocol": {
@@ -2118,8 +2118,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#16f766e89ff56bbe809319f89286bc364971f225",
-      "from": "github:brave/brave-ui#16f766e89ff56bbe809319f89286bc364971f225",
+      "version": "github:brave/brave-ui#eb5718f7820215da5144b95a0786c9e7ca3f4d16",
+      "from": "github:brave/brave-ui#eb5718f7820215da5144b95a0786c9e7ca3f4d16",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/react-dom": "^16.0.9",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "brave/brave-ui#16f766e89ff56bbe809319f89286bc364971f225",
+    "brave-ui": "brave/brave-ui#eb5718f7820215da5144b95a0786c9e7ca3f4d16",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Follow-up from https://github.com/brave/browser-android-tabs/pull/1593

Fixes brave-ui commit sha (the previous one was deleted due to a rebase on master).
Puts missing strings in since android uses a different brave_webui_source.cc to brave-core
Ensures grant type (ads or ugp) is always passed to all grant components.

