### PR TITLE
Rewards WebUI: fix alignment of 'totals' list content

### DIFF
--- a/components/brave_rewards_ui/BUILD.gn
+++ b/components/brave_rewards_ui/BUILD.gn
@@ -16,6 +16,7 @@ transpile_web_ui("transpile_settings") {
     "resources/components/grant.tsx",
     "resources/components/pageWallet.tsx",
     "resources/components/settingsPage.tsx",
+    "resources/components/style.ts",
     "resources/constants/rewards_types.ts",
     "resources/reducers/index.ts",
     "resources/reducers/grant_reducer.ts",

--- a/components/brave_rewards_ui/resources/components/style.ts
+++ b/components/brave_rewards_ui/resources/components/style.ts
@@ -44,6 +44,7 @@ export const StyledText = styled<{}, 'p'>('p')`
 export const StyledTotalContent = styled<{}, 'div'>('div')`
   position: relative;
   padding-right: 25px;
+  text-align: right;
 
   @media (max-width: 366px) {
     top: 11px;


### PR DESCRIPTION
Rewards WebUI: Fix alignment of 'totals' list content 
Implementations are: Ads earnings value, and contribution number of supported sites.

Also
fix missing input for BUILD

---

![image](https://user-images.githubusercontent.com/741836/58580124-41153d80-8201-11e9-8c93-1818db1fa5ae.png)

---


![image](https://user-images.githubusercontent.com/741836/58580138-470b1e80-8201-11e9-8870-fe701100b65a.png)
