### PR TITLE
Rewards WebUI: Do not overwrite ads log data when receiving other ads properties

### DIFF
--- a/components/brave_rewards_ui/resources/reducers/rewards_reducer.ts
+++ b/components/brave_rewards_ui/resources/reducers/rewards_reducer.ts
@@ -72,8 +72,13 @@ const rewardsReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State
           break
         }
 
-        state = { ...state }
-        state.adsData = action.payload.adsData
+        state = {
+          ...state,
+          adsData: {
+            ...state.adsData,
+            ...action.payload.adsData
+          }
+        }
         break
       }
     case types.ON_ADS_SETTING_SAVE:


### PR DESCRIPTION
Fix https://github.com/brave/browser-android-tabs/issues/1604
Fix https://github.com/brave/browser-android-tabs/issues/1610