### PR TITLE
Fixed sync resetting when network is down

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveSyncWorker.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveSyncWorker.java
@@ -2850,7 +2850,11 @@ public class BraveSyncWorker {
                 break;
               case "sync-setup-error":
                 Log.e(TAG, "sync-setup-error , !!!arg1 == " + arg1 + ", arg2 == " + arg2);
-                ResetSync();
+                if (mBaseOrder == null || mBaseOrder.isEmpty()) {
+                    // If base order is null, it means that sync wasn't yet initialized and failed to do so
+                    // We need to reset state before the next attempt
+                    ResetSync();
+                }
                 if (null != mSyncScreensObserver) {
                     mSyncScreensObserver.onSyncError(arg1);
                 }


### PR DESCRIPTION
Closes https://github.com/brave/browser-android-tabs/issues/1535
Closes https://github.com/brave/browser-android-tabs/issues/1354

I think we need more testing regarding network disconnects.