### PR TITLE
Issue-1495 Remove 'Set as default browser' from the settings menu

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/appmenu/AppMenu.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/appmenu/AppMenu.java
@@ -246,7 +246,7 @@ public class AppMenu implements OnItemClickListener, OnKeyListener {
             }
             if (item.getItemId() == R.id.brave_set_default_browser &&
                 BraveSetDefaultBrowserNotificationService.isBraveSetAsDefaultBrowser(context)) {
-                item.setEnabled(false);
+                item.setVisible(false);
             }
             if (item.isVisible()) {
                 menuItems.add(item);


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/1495