### PR TITLE
Disable auto-contribute doesn't hide the separators in BR panel

### DIFF
--- a/chrome/android/java/res/layout/brave_rewards_auto_contrib.xml
+++ b/chrome/android/java/res/layout/brave_rewards_auto_contrib.xml
@@ -36,13 +36,15 @@
     </RelativeLayout>
 
     <View
+        android:id="@+id/brave_ui_auto_contribute_separator_top"
         android:layout_width="fill_parent"
         android:layout_height="1dp"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
         android:layout_marginStart="10dp"
         android:layout_marginEnd="10dp"
-        android:background="#c0c0c0"/>
+        android:background="#c0c0c0"
+        android:visibility="gone"/>
 
 
     <!-- Include in AC list row-->
@@ -105,12 +107,14 @@
     </RelativeLayout>
 
     <View
+        android:id="@+id/brave_ui_auto_contribute_separator_bottom"
         android:layout_width="fill_parent"
         android:layout_height="1dp"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
         android:layout_marginStart="10dp"
         android:layout_marginEnd="10dp"
-        android:background="#c0c0c0"/>
+        android:background="#c0c0c0"
+        android:visibility="gone"/>
 
 </LinearLayout>

--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsPanelPopup.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsPanelPopup.java
@@ -1346,6 +1346,8 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
             if (mAutoContributeEnabled){
                 root.findViewById(R.id.attention_layout).setVisibility(View.VISIBLE);
                 root.findViewById(R.id.include_in_ac_layout).setVisibility(View.VISIBLE);
+                root.findViewById(R.id.brave_ui_auto_contribute_separator_top).setVisibility(View.VISIBLE);
+                root.findViewById(R.id.brave_ui_auto_contribute_separator_bottom).setVisibility(View.VISIBLE);
             }
 
             //Temporary commented out due to dropdown spinner inflating issue on PopupWindow (API 24)


### PR DESCRIPTION
Addresses : https://github.com/brave/browser-android-tabs/issues/1671