### PR TITLE
Skip adblock check for sync lib requests

### DIFF
--- a/chrome/browser/net/blockers/blockers_worker.cc
+++ b/chrome/browser/net/blockers/blockers_worker.cc
@@ -380,11 +380,18 @@ namespace blockers {
         return true;
     }
 
-    bool BlockersWorker::shouldAdBlockUrl(const std::string& base_host, const std::string& url,
+    bool BlockersWorker::shouldAdBlockUrl(const std::string& tab_url, const std::string& url,
                                           unsigned int resource_type, bool isAdBlockRegionalEnabled) {
         if (!isAdBlockerInitialized()) {
           return false;
         }
+
+        // Skip check for sync requests
+        if (tab_url == "file:///android_asset/") {
+          return false;
+        }
+
+        std::string base_host = GURL(tab_url).host();
 
         FilterOption currentOption = ResourceTypeToFilterOption((content::ResourceType)resource_type);
 

--- a/chrome/browser/net/blockers/blockers_worker.h
+++ b/chrome/browser/net/blockers/blockers_worker.h
@@ -41,7 +41,7 @@ public:
     ~BlockersWorker();
 
     bool shouldTPBlockUrl(const std::string& base_host, const std::string& host);
-    bool shouldAdBlockUrl(const std::string& base_host, const std::string& url, unsigned int resource_type,
+    bool shouldAdBlockUrl(const std::string& tab_url, const std::string& url, unsigned int resource_type,
       bool isAdBlockRegionalEnabled);
     std::string getHTTPSURLFromCacheOnly(const GURL* url, const uint64_t &request_id);
     std::string getHTTPSURL(const GURL* url, const uint64_t &request_id);


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/1791 .
Workaround to avoid sync requests be blocked by adblocks lib.