### PR TITLE
Fix turning on Brave Ads will cause some websites to display the “something went wrong” error message

### DIFF
--- a/components/dom_distiller/content/browser/distiller_page_web_contents.cc
+++ b/components/dom_distiller/content/browser/distiller_page_web_contents.cc
@@ -180,7 +180,9 @@ void DistillerPageWebContents::ExecuteJavaScript() {
   content::WebContentsObserver::Observe(nullptr);
   // Stop any pending navigation since the intent is to distill the current
   // page.
-  source_page_handle_->web_contents()->Stop();
+  if (source_page_handle_->web_contents()->GetDelegate() == this)
+      source_page_handle_->web_contents()->Stop();
+
   DVLOG(1) << "Beginning distillation";
   RunIsolatedJavaScript(
       frame, script_,


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/1844
