### PR TITLE
YT verified pubs favicon is not displayed in A-C table. Issue #1635

### DIFF
--- a/components/brave_rewards_ui/resources/components/contributeBox.tsx
+++ b/components/brave_rewards_ui/resources/components/contributeBox.tsx
@@ -45,17 +45,17 @@ class ContributeBox extends React.Component<Props, State> {
 
   getContributeRows = (list: Rewards.Publisher[]) => {
     return list.map((item: Rewards.Publisher) => {
-      let name = item.name
-      if (item.provider) {
-        name = `${name} ${getLocale('on')} ${item.provider}`
+      let faviconUrl = `chrome://favicon/size/48@1x/${item.url}`
+      if (item.favIcon && item.verified) {
+        faviconUrl = `chrome://favicon/size/48@1x/${item.favIcon}`
       }
 
       return {
         profile: {
-          name,
+          name: item.name,
           verified: item.verified,
           provider: (item.provider ? item.provider : undefined) as Provider,
-          src: `chrome://favicon/size/48@1x/${item.url}/`
+          src: faviconUrl
         },
         url: item.url,
         attention: item.percentage,


### PR DESCRIPTION
Pulled changes from desktop UI implementation at `src/brave/components/brave_rewards/resources`.
Resolves issue:  https://github.com/brave/browser-android-tabs/issues/1635.
