### PR TITLE
Turn off haptics for Brave Ads Notifications.Issue #1866

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/notifications/BraveAdsNotificationBuilder.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/notifications/BraveAdsNotificationBuilder.java
@@ -29,6 +29,7 @@ import org.chromium.base.ApiCompatibilityUtils;
 import org.chromium.base.Log;
 import org.chromium.base.VisibleForTesting;
 import org.chromium.base.metrics.RecordHistogram;
+import org.chromium.chrome.browser.notifications.channels.ChannelDefinitions;
 import org.chromium.chrome.R;
 import org.chromium.ui.base.LocalizationUtils;
 
@@ -107,7 +108,7 @@ public class BraveAdsNotificationBuilder extends NotificationBuilderBase {
         bigView.setInt(R.id.body, "setMaxLines", calculateMaxBodyLines(fontScale));
         int scaledPadding =
                 calculateScaledPadding(fontScale, mContext.getResources().getDisplayMetrics());
-        setChannelId("com.brave.browser.ads");
+        setChannelId(ChannelDefinitions.ChannelId.BRAVE_ADS);
 
         for (RemoteViews view : new RemoteViews[] {compactView, bigView}) {
             view.setTextViewText(R.id.title, mTitle);

--- a/chrome/android/java/src/org/chromium/chrome/browser/notifications/NotificationPlatformBridge.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/notifications/NotificationPlatformBridge.java
@@ -584,7 +584,8 @@ public class NotificationPlatformBridge {
         // The Android framework applies a fallback vibration pattern for the sound when the device
         // is in vibrate mode, there is no custom pattern, and the vibration default has been
         // disabled. To truly prevent vibration, provide a custom empty pattern.
-        boolean vibrateEnabled = PrefServiceBridge.getInstance().isNotificationsVibrateEnabled();
+        boolean vibrateEnabled = (isBraveAdNotification()) ? false
+            : PrefServiceBridge.getInstance().isNotificationsVibrateEnabled();
         if (!vibrateEnabled) {
             vibrationPattern = EMPTY_VIBRATION_PATTERN;
         }
@@ -646,7 +647,7 @@ public class NotificationPlatformBridge {
 
     /** Returns whether to set a channel id when building a notification. */
     private boolean shouldSetChannelId(boolean forWebApk) {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !forWebApk;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !forWebApk && !isBraveAdNotification();
     }
 
     /**

--- a/chrome/android/java/src/org/chromium/chrome/browser/notifications/channels/ChannelsInitializer.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/notifications/channels/ChannelsInitializer.java
@@ -162,6 +162,8 @@ public class ChannelsInitializer {
             }
             if (channelId.equals(ChannelDefinitions.ChannelId.BRAVE_ADS)) {
                 channel.setShowBadge(false);
+                channel.setVibrationPattern(new long[]{0L});
+                channel.enableVibration(true);
             }
             channelGroups.put(channelGroup.getId(), channelGroup);
             channels.put(channel.getId(), channel);


### PR DESCRIPTION
Turns off haptics for Android versions with or without notifications channels.
Closes #1866.