### PR TITLE
Uses one decimal places for BAT values in Brave Rewards

### DIFF
--- a/components/brave_rewards_ui/resources/components/adsBox.tsx
+++ b/components/brave_rewards_ui/resources/components/adsBox.tsx
@@ -88,7 +88,7 @@ class AdsBox extends React.Component<Props, {}> {
       adsEnabled = adsData.adsEnabled
       adsUIEnabled = adsData.adsUIEnabled
       adsIsSupported = adsData.adsIsSupported
-      estimatedPendingRewards = (adsData.adsEstimatedPendingRewards || 0).toFixed(2)
+      estimatedPendingRewards = (adsData.adsEstimatedPendingRewards || 0).toFixed(1)
       nextPaymentDate = adsData.adsNextPaymentDate
       adNotificationsReceivedThisMonth = adsData.adsAdNotificationsReceivedThisMonth || 0
     }

--- a/components/brave_rewards_ui/resources/components/pageWallet.tsx
+++ b/components/brave_rewards_ui/resources/components/pageWallet.tsx
@@ -58,7 +58,7 @@ class PageWallet extends React.Component<Props, State> {
 
     return grants.map((grant: Rewards.Grant) => {
       return {
-        tokens: utils.convertProbiToFixed(grant.probi, 2, BigNumber.ROUND_HALF_UP),
+        tokens: utils.convertProbiToFixed(grant.probi, 1, BigNumber.ROUND_HALF_UP),
         expireDate: new Date(grant.expiryTime * 1000).toLocaleDateString(),
         type: grant.type
       }
@@ -91,7 +91,7 @@ class PageWallet extends React.Component<Props, State> {
         const item = report[key]
 
         if (item.length > 1 && key !== 'total') {
-          const tokens = utils.convertProbiToFixed(item, 2, BigNumber.ROUND_HALF_UP)
+          const tokens = utils.convertProbiToFixed(item, 1, BigNumber.ROUND_HALF_UP)
           props[key] = {
             tokens,
             converted: utils.convertBalance(tokens, balance.rates)
@@ -116,7 +116,7 @@ class PageWallet extends React.Component<Props, State> {
     } = this.props.rewardsData
     const { emptyWallet } = ui
     const { total } = balance
-    const pendingTotal = parseFloat((pendingContributionTotal || 0).toFixed(2))
+    const pendingTotal = parseFloat((pendingContributionTotal || 0).toFixed(1))
 
     if (!visible) {
       return null
@@ -130,7 +130,7 @@ class PageWallet extends React.Component<Props, State> {
           </StyledWalletClose>
           <StyledWalletWrapper>
             <WalletWrapper
-              balance={total.toFixed(2)}
+              balance={total.toFixed(1)}
               converted={utils.formatConverted(this.getConversion())}
               actions={[]}
               compact={true}

--- a/components/brave_rewards_ui/resources/components/settingsPage.tsx
+++ b/components/brave_rewards_ui/resources/components/settingsPage.tsx
@@ -187,7 +187,7 @@ class SettingsPage extends React.Component<Props, State> {
         }
         <WalletInfoHeader
           onClick={this.onToggleWallet}
-          balance={total.toFixed(2).toString()}
+          balance={total.toFixed(1).toString()}
           id={'mobile-wallet'}
           converted={`${convertedBalance} USD`}
         />


### PR DESCRIPTION
Fixes: https://github.com/brave/browser-android-tabs/issues/1964