### PR TITLE
Fixed console errors on rewards page

### DIFF
--- a/chrome/browser/ui/webui/brave_webui_source.cc
+++ b/chrome/browser/ui/webui/brave_webui_source.cc
@@ -107,8 +107,8 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "contributionVisitSome",  IDS_BRAVE_REWARDS_LOCAL_CONTR_VISIT_SOME },
         { "contributionMinTime",  IDS_BRAVE_REWARDS_LOCAL_CONTR_MIN_TIME },
         { "contributionMinVisits",  IDS_BRAVE_REWARDS_LOCAL_CONTR_MIN_VISITS },
-        // { "contributionAllowed",  IDS_BRAVE_REWARDS_LOCAL_CONTR_ALLOWED },
-        // { "contributionNonVerified",  IDS_BRAVE_REWARDS_LOCAL_CONTR_ALLOW_NON_VERIFIED },        // NOLINT
+        { "contributionOther",  IDS_BRAVE_REWARDS_LOCAL_CONTR_OTHER },
+        { "contributionShowNonVerified",  IDS_BRAVE_REWARDS_LOCAL_CONTR_SHOW_NON_VERIFIED },        // NOLINT
         { "contributionVideos",  IDS_BRAVE_REWARDS_LOCAL_CONTR_ALLOW_VIDEOS },
         { "contributionVisit1",  IDS_BRAVE_REWARDS_LOCAL_CONTR_VISIT_1 },
         { "contributionVisit5",  IDS_BRAVE_REWARDS_LOCAL_CONTR_VISIT_5 },

--- a/components/brave_rewards_ui/resources/components/contributeBox.tsx
+++ b/components/brave_rewards_ui/resources/components/contributeBox.tsx
@@ -165,7 +165,7 @@ class ContributeBox extends React.Component<Props, State> {
               ]}
             />
           </ControlWrapper>
-          <ControlWrapper text={getLocale('contributionAllowed')}>
+          <ControlWrapper text={getLocale('contributionOther')}>
             <Checkbox
               value={{
                 contributionNonVerified: contributionNonVerified,
@@ -174,7 +174,7 @@ class ContributeBox extends React.Component<Props, State> {
               multiple={true}
               onChange={this.onCheckSettingChange}
             >
-              <div data-key='contributionNonVerified'>{getLocale('contributionNonVerified')}</div>
+              <div data-key='contributionNonVerified'>{getLocale('contributionShowNonVerified')}</div>
               <div data-key='contributionVideos'>{getLocale('contributionVideos')}</div>
             </Checkbox>
           </ControlWrapper>


### PR DESCRIPTION
This PR fixes `contributionAllowed` and `contributionNonVerified` errors in console on rewards settings page.