### PR TITLE
fixes 0 tips amount in rewards settings page

### DIFF
--- a/components/brave_rewards_ui/resources/components/donationsBox.tsx
+++ b/components/brave_rewards_ui/resources/components/donationsBox.tsx
@@ -79,7 +79,7 @@ class DonationBox extends React.Component<Props, {}> {
           faviconUrl = `chrome://favicon/size/48@1x/${item.favIcon}`
         }
 
-        const token = utils.convertProbiToFixed(item.percentage.toString())
+        const token = parseFloat(item.percentage.toString()).toFixed(1)
 
         return {
           profile: {


### PR DESCRIPTION
closes https://github.com/brave/browser-android-tabs/issues/2394