### PR TITLE
Check getActivityTab() result for null; fixes browser-android-tabs#2412

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
@@ -658,7 +658,8 @@ public class ChromeTabbedActivity extends ChromeActivity implements ScreenshotMo
             mTabModelObserver = new TabModelSelectorTabModelObserver(mTabModelSelectorImpl) {
                 @Override
                 public void didSelectTab(Tab tab, @TabSelectionType int type, int lastId) {
-                    if (getActivityTab().equals(tab)) {
+                    final Tab currentTab = getActivityTab();
+                    if (currentTab != null && currentTab.equals(tab)) {
                         onNotifyFrontTabUrlChanged(tab, tab.getUrl());
                     }
 
@@ -1834,7 +1835,8 @@ public class ChromeTabbedActivity extends ChromeActivity implements ScreenshotMo
                 if ((null != app) && (null != app.getShieldsConfig())) {
                     app.getShieldsConfig().setTabModelSelectorTabObserver(mTabModelSelectorTabObserver);
                 }
-                if (getActivityTab() == tab) {
+                final Tab currentTab = getActivityTab();
+                if (currentTab != null && currentTab == tab) {
                     try {
                         URL urlCheck = new URL(url);
                         setBraveShieldsColor(tab.isIncognito(), urlCheck.getHost());
@@ -1847,7 +1849,8 @@ public class ChromeTabbedActivity extends ChromeActivity implements ScreenshotMo
 
             @Override
             public void onPageLoadFinished(final Tab tab, String url) {
-                if (getActivityTab() == tab) {
+                final Tab currentTab = getActivityTab();
+                if (currentTab != null && currentTab == tab) {
                     try {
                         URL urlCheck = new URL(url);
                         setBraveShieldsColor(tab.isIncognito(), urlCheck.getHost());
@@ -1859,7 +1862,8 @@ public class ChromeTabbedActivity extends ChromeActivity implements ScreenshotMo
 
             @Override
             public void onDidFinishNavigation(Tab tab, NavigationHandle navigation) {
-                if (getActivityTab().equals(tab)) {
+                final Tab currentTab = getActivityTab();
+                if (currentTab != null && currentTab.equals(tab)) {
                     onNotifyFrontTabUrlChanged(tab, tab.getUrl());
                 }
 
@@ -2716,8 +2720,9 @@ public class ChromeTabbedActivity extends ChromeActivity implements ScreenshotMo
         // Find if tab exists
         if (tabRewardsIndex != TabModel.INVALID_TAB_INDEX){
             Tab tab = tabModel.getTabAt(tabRewardsIndex);
+            final Tab currentTab = getActivityTab();
             // Moving tab forward
-            if (!getActivityTab().equals(tab)){
+            if (currentTab != null && !currentTab.equals(tab)) {
                 tabModel.moveTab(tab.getId(), tabModel.getCount());
                 tabModel.setIndex(
                         TabModelUtils.getTabIndexById(tabModel, tab.getId()),


### PR DESCRIPTION
Fixes https://github.com/brave/browser-android-tabs/issues/2412