### PR TITLE
Fix for crash in bookmark bridge

### DIFF
--- a/chrome/browser/android/bookmarks/bookmark_bridge.cc
+++ b/chrome/browser/android/bookmarks/bookmark_bridge.cc
@@ -433,6 +433,10 @@ jint BookmarkBridge::GetChildCount(JNIEnv* env,
                                     jint type) {
   DCHECK(IsLoaded());
   const BookmarkNode* node = GetNodeByID(id, type);
+  if (!node) {
+    NOTREACHED();
+    return jint{0};
+  }
   return jint{node->children().size()};
 }
 


### PR DESCRIPTION
Potential fix for crash #9 from https://github.com/brave/browser-android-tabs/issues/2435