### PR TITLE
Handling new rewards notifications. Issue# 2198

### DIFF
--- a/chrome/android/java/res/layout/brave_rewards_panel_grant.xml
+++ b/chrome/android/java/res/layout/brave_rewards_panel_grant.xml
@@ -79,6 +79,8 @@
             android:layout_gravity="center"
             android:fontFamily="sans-serif"
             android:textSize="14sp"
+            android:paddingStart="15dp"
+            android:paddingEnd="15dp"
             android:textColor="#FFFFFF"
             android:visibility="gone"/>
     </FrameLayout>

--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsNativeWorker.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsNativeWorker.java
@@ -36,6 +36,9 @@ public class BraveRewardsNativeWorker {
     public static final int REWARDS_NOTIFICATION_IMPENDING_CONTRIBUTION = 5;
     public static final int REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS = 6;
     public static final int REWARDS_NOTIFICATION_BACKUP_WALLET = 7;
+    public static final int REWARDS_NOTIFICATION_TIPS_PROCESSED = 8;
+    public static final int REWARDS_NOTIFICATION_ADS_ONBOARDING = 9;
+    public static final int REWARDS_NOTIFICATION_VERIFIED_PUBLISHER = 10;
 
     public static final int LEDGER_OK = 0;
     public static final int LEDGER_ERROR = 1;

--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsPanelPopup.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsPanelPopup.java
@@ -562,48 +562,6 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
               }
             }));
         }
-        Button btClaimOk = (Button)root.findViewById(R.id.br_claim_button);
-        if (btClaimOk != null) {
-          btClaimOk.setOnClickListener((new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-              Button claimOk = (Button)v;
-              if (claimOk.getText().toString().equals(
-                root.getResources().getString(R.string.ok))) {
-                  if (mBraveRewardsNativeWorker != null) {
-                      mBraveRewardsNativeWorker.DeleteNotification(currentNotificationId);
-                  }
-              }
-              else if (mBraveRewardsNativeWorker != null) {
-                  //disable and hide CLAIM button
-                  claimOk.setEnabled(false);
-
-                  //claimOk.setEnabled(false) sometimes not fast enough, so block multiple 'Claim' clicks
-                  if (mClaimInProcess || currentNotificationId.isEmpty()){
-                      return;
-                  }
-
-                  int prom_id_separator = currentNotificationId.lastIndexOf(NOTIFICATION_PROMID_SEPARATOR);
-                  String promId = "";
-                  if (-1 != prom_id_separator ) {
-                      promId = currentNotificationId.substring(prom_id_separator + 1);
-                  }
-                  if (promId.isEmpty()){
-                      return;
-                  }
-
-                  mClaimInProcess = true;
-
-                  View fadein = root.findViewById(R.id.progress_br_claim_button);
-                  BraveRewardsHelper.crossfade(claimOk, fadein, View.GONE, 1f, BraveRewardsHelper.CROSS_FADE_DURATION);
-
-                  mBraveRewardsNativeWorker.GetGrant(promId);
-                  walletDetailsReceived = false; //re-read wallet status
-                  EnableWalletDetails(false);
-              }
-            }
-          }));
-        }
     }
 
     private void SetRewardsSummaryMonthYear() {
@@ -828,20 +786,33 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
         }
     }
 
-    private boolean IsValidNotificationType(int type){
+    /**
+     * Validates if a notification can be processed and has an expected
+     * number of arguments
+     */
+    private boolean IsValidNotificationType(int type, int argsNum){
         boolean valid = false;
+
         switch (type) {
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_AUTO_CONTRIBUTE:
+                valid  = (argsNum >= 4) ? true : false;
+                break;
+            case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_VERIFIED_PUBLISHER:
+                valid  = (argsNum >= 1) ? true : false;
+                break;
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_GRANT:
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_GRANT_ADS:
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS:
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_BACKUP_WALLET:
+            case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_TIPS_PROCESSED:
+            case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_ADS_ONBOARDING:
             case REWARDS_NOTIFICATION_NO_INTERNET:
                 valid = true;
                 break;
             default:
                 valid = false;
         }
+        Log.i(TAG, "IsValidNotificationType: type %d argnum %d ", type, argsNum);
         return valid;
     }
 
@@ -850,7 +821,7 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
             String[] args) {
 
         // don't process unknown notifications
-        if ( !IsValidNotificationType (type) && mBraveRewardsNativeWorker != null) {
+        if ( !IsValidNotificationType (type, args.length) && mBraveRewardsNativeWorker != null) {
             mBraveRewardsNativeWorker.DeleteNotification(id);
             return;
         }
@@ -899,16 +870,15 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
         // TODO other types of notifications
         switch (type) {
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_AUTO_CONTRIBUTE:
-                if (args.length >= 4) {
-                    // TODO find the case where it is used
-                    notification_icon.setImageResource(R.drawable.icon_validated_notification);
-                    String result = args[1];
-                    switch (result) {
-                        case AUTO_CONTRIBUTE_SUCCESS:
-                            btClaimOk.setText(root.getResources().getString(R.string.ok));
-                            title = root.getResources().getString(R.string.brave_ui_rewards_contribute);
-                            notification_icon.setImageResource(R.drawable.contribute_icon);
-                            hl.setBackgroundResource(R.drawable.notification_header_normal);
+                // TODO find the case where it is used
+                notification_icon.setImageResource(R.drawable.icon_validated_notification);
+                String result = args[1];
+                switch (result) {
+                    case AUTO_CONTRIBUTE_SUCCESS:
+                        btClaimOk.setText(root.getResources().getString(R.string.ok));
+                        title = root.getResources().getString(R.string.brave_ui_rewards_contribute);
+                        notification_icon.setImageResource(R.drawable.contribute_icon);
+                        hl.setBackgroundResource(R.drawable.notification_header_normal);
 
                             double value = 0;
                             String valueString = "";
@@ -955,9 +925,6 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
                         nit.setLayoutParams(params);
                         tv.setGravity(Gravity.START);
                     }
-                } else {
-                    assert false : "Not enough data to process rewards notification";
-                }
                 break;
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_GRANT:
             case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_GRANT_ADS:
@@ -987,6 +954,25 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
                 title = root.getResources().getString(R.string.brave_ui_backup_wallet_msg);
                 description = root.getResources().getString(R.string.brave_ui_backup_wallet_desc);
                 break;
+            case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_TIPS_PROCESSED:
+                btClaimOk.setText(root.getResources().getString(R.string.ok));
+                title = root.getResources().getString(R.string.brave_ui_contribution_tips);
+                description = root.getResources().getString(R.string.brave_ui_tips_processed_notification);
+                notification_icon.setImageResource(R.drawable.contribute_icon);
+                break;
+            case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_ADS_ONBOARDING:
+                btClaimOk.setText(root.getResources().getString(R.string.brave_ui_turn_on_ads));
+                title = root.getResources().getString(R.string.brave_ui_brave_ads_launch_title);
+                description = root.getResources().getString(R.string.brave_ui_brave_ads_launch_msg);
+                notification_icon.setImageResource(R.drawable.notification_icon);
+                break;
+            case BraveRewardsNativeWorker.REWARDS_NOTIFICATION_VERIFIED_PUBLISHER:
+                String pubName = args[0];
+                btClaimOk.setText(root.getResources().getString(R.string.ok));
+                title = root.getResources().getString(R.string.brave_ui_pending_contribution_title);
+                description = root.getResources().getString(R.string.brave_ui_verified_publisher_notification, pubName);
+                notification_icon.setImageResource(R.drawable.contribute_icon);
+                break;
             case REWARDS_NOTIFICATION_NO_INTERNET:
                 title = "";
                 notification_icon.setImageResource(R.drawable.icon_error_notification);
@@ -1009,6 +995,64 @@ public class BraveRewardsPanelPopup implements BraveRewardsObserver, BraveReward
           (title.isEmpty() ? "" : ("  <font color=#a9aab4>" + notificationTime + "</font>"));
         Spanned toInsert = BraveRewardsHelper.spannedFromHtmlString(stringToInsert);
         tv.setText(toInsert);
+
+        SetNotificationButtoClickListener();
+    }
+
+    private void SetNotificationButtoClickListener() {
+        Button btClaimOk = (Button)root.findViewById(R.id.br_claim_button);
+        String strAction = (btClaimOk != null && mBraveRewardsNativeWorker != null )? btClaimOk.getText().toString() : "";
+        if (strAction.equals(root.getResources().getString(R.string.ok)))
+        {
+            btClaimOk.setOnClickListener( new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mBraveRewardsNativeWorker.DeleteNotification(currentNotificationId);
+                }
+            });
+        }
+        else if (strAction.equals(root.getResources().getString(R.string.brave_ui_claim))){
+            btClaimOk.setOnClickListener( new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    //disable and hide CLAIM button
+                    btClaimOk.setEnabled(false);
+
+                    //btClaimOk.setEnabled(false) sometimes not fast enough, so block multiple 'Claim' clicks
+                    if (mClaimInProcess || currentNotificationId.isEmpty()){
+                        return;
+                    }
+
+                    int prom_id_separator = currentNotificationId.lastIndexOf(NOTIFICATION_PROMID_SEPARATOR);
+                    String promId = "";
+                    if (-1 != prom_id_separator ) {
+                        promId = currentNotificationId.substring(prom_id_separator + 1);
+                    }
+                    if (promId.isEmpty()){
+                        return;
+                    }
+
+                    mClaimInProcess = true;
+
+                    View fadein = root.findViewById(R.id.progress_br_claim_button);
+                    BraveRewardsHelper.crossfade(btClaimOk, fadein, View.GONE, 1f, BraveRewardsHelper.CROSS_FADE_DURATION);
+
+                    mBraveRewardsNativeWorker.GetGrant(promId);
+                    walletDetailsReceived = false; //re-read wallet status
+                    EnableWalletDetails(false);
+                }
+            });
+        }
+        else if (strAction.equals(root.getResources().getString(R.string.brave_ui_turn_on_ads))){
+            btClaimOk.setOnClickListener( new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mBraveRewardsNativeWorker.DeleteNotification(currentNotificationId);
+                    mActivity.openNewOrSelectExistingTab (ChromeTabbedActivity.REWARDS_SETTINGS_URL);
+                    dismiss();
+                }
+            });
+        }
     }
 
     private void DismissNotification(String id) {

--- a/chrome/android/java/strings/android_chrome_strings.grd
+++ b/chrome/android/java/strings/android_chrome_strings.grd
@@ -4776,7 +4776,27 @@ content creators you love.
       </message>
 
       <message name="IDS_PHOTO_BY" desc="TExt for image credit for background images on NTP">Photo by <ph name="PHOTO_BY">%1$s</ph></message>
-
+      <message name="IDS_BRAVE_UI_TIPS_PROCESSED_NOTIFICATION" desc="Message for monthly tips processed notification">
+        Your monthly tips have been processed!
+      </message>
+      <message name="IDS_BRAVE_UI_CONTRIBUTION_TIPS" desc="Title for monthly tips processed notification">
+        Contributions &amp; Tips
+      </message>
+      <message name="IDS_BRAVE_UI_BRAVE_ADS_LAUNCH_MSG" desc="Message for ads launch notification">
+        Now you can earn by viewing ads.
+      </message>
+      <message name="IDS_BRAVE_UI_TURN_ON_ADS" desc="Prompt to turn on Ads via notification">
+        Turn on Ads
+      </message>
+      <message name="IDS_BRAVE_UI_BRAVE_ADS_LAUNCH_TITLE" desc="Message used in notification to let users know Ads is available">
+        Brave Ads has arrived!
+      </message>
+      <message name="IDS_BRAVE_UI_VERIFIED_PUBLISHER_NOTIFICATION" desc="Notification text that tells user which publisher just verified">
+        Creator <ph name="PUBLISHER_NAME">%1$s<ex>brave.com</ex></ph> recently verified
+      </message>
+      <message name="IDS_BRAVE_UI_PENDING_CONTRIBUTION_TITLE" desc="Notification title for pending contribution type">
+        Pending Contribution
+      </message>
     </messages>
   </release>
 </grit>

--- a/chrome/android/java/strings/strings.xml
+++ b/chrome/android/java/strings/strings.xml
@@ -329,5 +329,11 @@ content creators you love.</string>
     <string name="ten_tip_option">10 <ph name="TIP">%1$s<ex>BAT</ex></ph></string>
 
     <string name="photo_by">Photo by <ph name="PHOTO_BY">%1$s</ph></string>
-
+    <string name="brave_ui_tips_processed_notification">Your monthly tips have been processed!</string>
+    <string name="brave_ui_contribution_tips">Contributions &amp; Tips</string>
+    <string name="brave_ui_brave_ads_launch_msg">Now you can earn by viewing ads.</string>
+    <string name="brave_ui_turn_on_ads">Turn on Ads</string>
+    <string name="brave_ui_brave_ads_launch_title">Brave Ads has arrived!</string>
+    <string name="brave_ui_verified_publisher_notification">Creator <ph name="PUBLISHER_NAME">%1$s</ph> recently verified</string>
+    <string name="brave_ui_pending_contribution_title">Pending Contribution</string>
 </resources>


### PR DESCRIPTION
Duplicate of obsolete: https://github.com/brave/browser-android-tabs/pull/2302

Fixes: https://github.com/brave/browser-android-tabs/issues/2198

This PR handles 3 new rewards notifications:
REWARDS_NOTIFICATION_TIPS_PROCESSED,
REWARDS_NOTIFICATION_ADS_ONBOARDING,
REWARDS_NOTIFICATION_VERIFIED_PUBLISHER

These two will be covered by separate issue #2303:
REWARDS_NOTIFICATION_PENDING_NOT_ENOUGH_FUNDS,
REWARDS_NOTIFICATION_GENERAL_LEDGER