### PR TITLE
Disable 32-bit abi for arm64 and x86_64

### DIFF
--- a/chrome/android/BUILD.gn
+++ b/chrome/android/BUILD.gn
@@ -1808,6 +1808,8 @@ if (public_android_sdk) {
     version_name = chrome_version_name
     apk_name = "BraveMono"
     target_type = "android_apk"
+    include_32_bit_webview = false
+    is_64_bit_browser = android_64bit_target_cpu
   }
 
   trichrome_library_apk_tmpl("trichrome_library_apk") {


### PR DESCRIPTION
Currently even arm64 and x86_64 Brave builds running on arm64 and x86_64 cpus display in `brave://version` (32-bit). The same behavior is for Chrome and Chromium.

This PR disables 32-bit abi as a secondary from being built for apk.

Note: there is an official gn-parameter `build_apk_secondary_abi` - but apk built with such parameter crashes on start on first call of a native call.

This PR is a draft, because on Debug monochrome arm64 there is an error
```
[17/26] SOLINK ./libmonochrome.so
FAILED: libmonochrome.so libmonochrome.so.TOC lib.unstripped/libmonochrome.so 
python "../../build/toolchain/gcc_solink_wrapper.py" --readelf="../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-readelf" --nm="../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-nm" --strip=../../buildtools/third_party/eu-strip/bin/eu-strip --sofile="./lib.unstripped/libmonochrome.so" --tocfile="./libmonochrome.so.TOC" --output="./libmonochrome.so" -- ../../third_party/llvm-build/Release+Asserts/bin/clang++ -shared -Wl,-soname="libmonochrome.so" -Wl,--version-script=gen/android_webview/monochrome_linker_script.txt -Wl,--hash-style=gnu -Wl,--fatal-warnings -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,-z,defs -Wl,--as-needed -fuse-ld=lld -Wl,-z,max-page-size=4096 -Wl,--color-diagnostics -Wl,--no-rosegment -Wl,--exclude-libs=libgcc.a -Wl,--exclude-libs=libvpx_assembly_arm.a -Wl,--allow-multiple-definition --target=aarch64-linux-android21 -Wl,-mllvm,-enable-machine-outliner=never -Werror -nostdlib++ --sysroot=../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot -B../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64 -Wl,--warn-shared-textrel -Wl,--pack-dyn-relocs=android -Wl,-wrap,calloc -Wl,-wrap,free -Wl,-wrap,malloc -Wl,-wrap,memalign -Wl,-wrap,posix_memalign -Wl,-wrap,pvalloc -Wl,-wrap,realloc -Wl,-wrap,valloc -Wl,--dynamic-linker,/system/bin/linker64 -o "./lib.unstripped/libmonochrome.so" @"./libmonochrome.so.rsp"
ld.lld: error: undefined symbol: Profile::FromBrowserContext(content::BrowserContext*)
>>> referenced by brave_tab_url_web_contents_observer.cc:32 (../../brave_src/browser/brave_tab_url_web_contents_observer.cc:32)
>>>               obj/brave_src/browser/browser_process/brave_tab_url_web_contents_observer.o:(brave::BraveTabUrlWebContentsObserver::RenderFrameCreated(content::RenderFrameHost*))

ld.lld: error: undefined symbol: HostContentSettingsMapFactory::GetForProfile(Profile*)
>>> referenced by brave_tab_url_web_contents_observer.cc:34 (../../brave_src/browser/brave_tab_url_web_contents_observer.cc:34)
>>>               obj/brave_src/browser/browser_process/brave_tab_url_web_contents_observer.o:(brave::BraveTabUrlWebContentsObserver::RenderFrameCreated(content::RenderFrameHost*))

ld.lld: error: undefined symbol: ProfileManager::GetActiveUserProfile()
>>> referenced by web_contents_ledger_observer.cc:34 (../../brave_src/browser/web_contents_ledger_observer.cc:34)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::WebContentsLedgerObserver(content::WebContents*))

ld.lld: error: undefined symbol: brave_rewards::RewardsServiceFactory::GetForProfile(Profile*)
>>> referenced by web_contents_ledger_observer.cc:33 (../../brave_src/browser/web_contents_ledger_observer.cc:33)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::WebContentsLedgerObserver(content::WebContents*))

ld.lld: error: undefined symbol: SessionTabHelper::IdForTab(content::WebContents const*)
>>> referenced by web_contents_ledger_observer.cc:47 (../../brave_src/browser/web_contents_ledger_observer.cc:47)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::OnVisibilityChanged(content::Visibility))
>>> referenced by web_contents_ledger_observer.cc:49 (../../brave_src/browser/web_contents_ledger_observer.cc:49)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::OnVisibilityChanged(content::Visibility))
>>> referenced by web_contents_ledger_observer.cc:55 (../../brave_src/browser/web_contents_ledger_observer.cc:55)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::WebContentsDestroyed())
>>> referenced by web_contents_ledger_observer.cc:66 (../../brave_src/browser/web_contents_ledger_observer.cc:66)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::DidFinishLoad(content::RenderFrameHost*, GURL const&))
>>> referenced by web_contents_ledger_observer.cc:83 (../../brave_src/browser/web_contents_ledger_observer.cc:83)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::DidAttachInterstitialPage())
>>> referenced by web_contents_ledger_observer.cc:94 (../../brave_src/browser/web_contents_ledger_observer.cc:94)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::DidFinishNavigation(content::NavigationHandle*))
>>> referenced by web_contents_ledger_observer.cc:111 (../../brave_src/browser/web_contents_ledger_observer.cc:111)
>>>               obj/brave_src/browser/browser_process/web_contents_ledger_observer.o:(brave::WebContentsLedgerObserver::ResourceLoadComplete(content::RenderFrameHost*, content::GlobalRequestID const&, content::mojom::ResourceLoadInfo const&))

ld.lld: error: undefined symbol: net::blockers::IsWhitelistedCookieExeption(GURL const&, GURL const&)
>>> referenced by cookie_settings.cc:248 (../../components/content_settings/core/browser/cookie_settings.cc:248)
>>>               browser/cookie_settings.o:(content_settings::CookieSettings::BraveShouldBlockThirdPartyCookies(GURL const&, GURL const&) const) in archive obj/components/content_settings/core/browser/libbrowser.a
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[18/26] ACTION //chrome/android:monochrome_public_apk__java__dex(//build/toolchain/android:android_clang_arm64)
```
which makes impossible debug.

All targets built by `scripts/buildReleasesAllAndModern.sh` still being built successfully.
Debug: arm classic, arm modern, arm mono; arm64 modern - succeeded.




