### PR TITLE
Claim multiple grants from the panel. Issue# 7763

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsNativeWorker.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsNativeWorker.java
@@ -541,6 +541,9 @@ public class BraveRewardsNativeWorker {
     @CalledByNative
     public void OnGrantFinish(int result) {
         grantClaimInProcess = false;
+        for(BraveRewardsObserver observer : observers_) {
+            observer.OnGrantFinish(result);
+        }
     }
 
     @CalledByNative

--- a/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsObserver.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/BraveRewardsObserver.java
@@ -24,4 +24,5 @@ public interface BraveRewardsObserver {
   public void OnResetTheWholeState(boolean success);
   public void OnRewardsMainEnabled(boolean enabled);
   default public void OnFetchPromotions() {};
+  default public void OnGrantFinish(int result) {};
 }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/7763.

The problem was: a processed notification is deleted before 'OnGrantFinish' is called. 'ShowNotification' draws a new notification without 'Claim/OK' button. 'OnGrantFinish' draws the button.